### PR TITLE
file entry names in zip files are now percent decoded

### DIFF
--- a/file-utils/src/main/resources/xml/xslt/uri-functions.xsl
+++ b/file-utils/src/main/resources/xml/xslt/uri-functions.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:pf="http://www.daisy.org/ns/pipeline/functions" exclude-result-prefixes="#all"
-    version="2.0">
+    version="2.0" xmlns:f="http://www.daisy.org/ns/pipeline/internal-functions">
 
     <xsl:function name="pf:tokenize-uri" as="xs:string*">
         <xsl:param name="uri" as="xs:string?"/>
@@ -136,6 +136,90 @@
                 <xsl:variable name="longest-common" select="for $i in 1 to count($a) return if ($longest-common[position()&lt;=$i]='	') then () else $longest-common[$i]"/>
                 <xsl:variable name="longest-common" select="concat($longest-common[1],if (matches($longest-common[1],'^\w+:/$') and not(matches($longest-common[1],'^file:/'))) then '/' else '',string-join($longest-common[position()&gt;1],''))"/>
                 <xsl:value-of select="string-join($longest-common,' | ')"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+    <!--
+        percent-decode(xs:string URI) - decodes a percent-encoded string
+        based on http://www.oxygenxml.com/archives/xsl-list/200911/msg00300.html by James A. Robinson
+    -->
+    <xsl:function name="pf:percent-decode" as="xs:string?">
+        <xsl:param name="in" as="xs:string"/>
+        <xsl:sequence select="f:percent-decode($in, ())"/>
+    </xsl:function>
+    <xsl:function name="f:percent-decode" as="xs:string?">
+        <xsl:param name="in" as="xs:string"/>
+        <xsl:param name="seq" as="xs:string*"/>
+        
+        <xsl:variable name="unreserved" as="xs:integer+" select="(45, 46, 48 to 57, 65 to 90, 95, 97 to 122, 126)"/>
+        
+        <xsl:choose>
+            <xsl:when test="not($in)">
+                <xsl:sequence select="string-join($seq, '')"/>
+            </xsl:when>
+            <xsl:when test="starts-with($in, '%')">
+                <xsl:choose>
+                    <xsl:when test="matches(substring($in, 2, 2), '^[0-9A-Fa-f][0-9A-Fa-f]$')">
+                        <xsl:variable name="s" as="xs:string" select="substring($in, 2, 2)"/>
+                        <xsl:variable name="d" as="xs:integer" select="f:hex-to-dec(upper-case($s))"/>
+                        <xsl:variable name="c" as="xs:string" select="codepoints-to-string($d)"/>
+                        <xsl:sequence select="f:percent-decode(substring($in, 4), ($seq, $c))"/>
+                    </xsl:when>
+                    <xsl:when test="contains(substring($in, 2), '%')">
+                        <xsl:variable name="s" as="xs:string" select="substring-before(substring($in, 2), '%')"/>
+                        <xsl:sequence select="f:percent-decode(substring($in, 2 + string-length($s)), ($seq, '%', $s))"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:sequence select="string-join(($seq, $in), '')"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:when test="contains($in, '%')">
+                <xsl:variable name="s" as="xs:string" select="substring-before($in, '%')"/>
+                <xsl:sequence select="f:percent-decode(substring($in, string-length($s)+1), ($seq, $s))"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="string-join(($seq, $in), '')"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    <!-- Private function to convert a hexadecimal string into decimal -->
+    <xsl:function name="f:hex-to-dec" as="xs:integer">
+        <xsl:param name="hex" as="xs:string"/>
+        
+        <xsl:variable name="len" as="xs:integer" select="string-length($hex)"/>
+        <xsl:choose>
+            <xsl:when test="$len eq 0">
+                <xsl:sequence select="0"/>
+            </xsl:when>
+            <xsl:when test="$len eq 1">
+                <xsl:sequence
+                    select="
+                    if ($hex eq '0')       then 0
+                    else if ($hex eq '1')       then 1
+                    else if ($hex eq '2')       then 2
+                    else if ($hex eq '3')       then 3
+                    else if ($hex eq '4')       then 4
+                    else if ($hex eq '5')       then 5
+                    else if ($hex eq '6')       then 6
+                    else if ($hex eq '7')       then 7
+                    else if ($hex eq '8')       then 8
+                    else if ($hex eq '9')       then 9
+                    else if ($hex = ('A', 'a')) then 10
+                    else if ($hex = ('B', 'b')) then 11
+                    else if ($hex = ('C', 'c')) then 12
+                    else if ($hex = ('D', 'd')) then 13
+                    else if ($hex = ('E', 'e')) then 14
+                    else if ($hex = ('F', 'f')) then 15
+                    else error(xs:QName('f:hex-to-dec'))
+                    "
+                />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="
+                    (16 * f:hex-to-dec(substring($hex, 1, $len - 1)))
+                    + f:hex-to-dec(substring($hex, $len))"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>

--- a/zip-utils/src/main/resources/xml/xslt/fileset-to-zip-manifest.xsl
+++ b/zip-utils/src/main/resources/xml/xslt/fileset-to-zip-manifest.xsl
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:d="http://www.daisy.org/ns/pipeline/data"
-    version="2.0" exclude-result-prefixes="d">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:d="http://www.daisy.org/ns/pipeline/data" version="2.0" exclude-result-prefixes="#all" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:pf="http://www.daisy.org/ns/pipeline/functions">
+
+    <xsl:import href="http://www.daisy.org/pipeline/modules/file-utils/xslt/uri-functions.xsl"/>
 
     <xsl:template match="d:fileset">
         <c:zip-manifest>
@@ -9,9 +10,9 @@
             <xsl:apply-templates select="*"/>
         </c:zip-manifest>
     </xsl:template>
-    
+
     <xsl:template match="d:file[@href and not(matches(@href,'^[^/]+:') or starts-with(@href,'..'))]">
-        <c:entry href="{@href}" name="{@href}"/>
+        <c:entry href="{@href}" name="{pf:percent-decode(@href)}"/>
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
the name of the entries in the zip manifest provided to px:zip must not be percent encoded

fixes issue 304: https://code.google.com/p/daisy-pipeline/issues/detail?id=304
