### PR TITLE
file-utils: URL normalization and more xspec tests

### DIFF
--- a/file-utils/src/test/uri-functions-result.html
+++ b/file-utils/src/test/uri-functions-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for home/jostein/pipeline-modules/common-utils/file-utils/src/main/resources/xml/xslt/uri-functions.xsl (passed:21 / pending:15 / failed:1 / total:37)</title>
+      <title>Test Report for home/jostein/pipeline-modules/common-utils/file-utils/src/main/resources/xml/xslt/uri-functions.xsl (passed:94 / pending:11 / failed:1 / total:106)</title>
       <link rel="stylesheet" type="text/css" href="file:/home/jostein/Oxygen%20XML%20Editor%2014/frameworks/xspec/src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
       <p xmlns:oxy="http://www.oxygenxml.com/xslt/xspec">Stylesheet: <a href="file:/home/jostein/pipeline-modules/common-utils/file-utils/src/main/resources/xml/xslt/uri-functions.xsl">home/jostein/pipeline-modules/common-utils/file-utils/src/main/resources/xml/xslt/uri-functions.xsl</a></p>
-      <p xmlns:oxy="http://www.oxygenxml.com/xslt/xspec">Tested: 13 May 2013 at 09:44</p>
+      <p xmlns:oxy="http://www.oxygenxml.com/xslt/xspec">Tested: 24 May 2013 at 17:05</p>
       <h2 xmlns:oxy="http://www.oxygenxml.com/xslt/xspec">Contents</h2>
       <table xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" class="xspec">
          <col width="80%" />
@@ -18,10 +18,10 @@
          <thead>
             <tr>
                <th></th>
-               <th class="result">passed:21</th>
-               <th class="result">pending:15</th>
+               <th class="result">passed:94</th>
+               <th class="result">pending:11</th>
                <th class="result">failed:1</th>
-               <th class="result">total:37</th>
+               <th class="result">total:106</th>
             </tr>
          </thead>
          <tbody>
@@ -74,71 +74,71 @@
                <th class="result">0</th>
                <th class="result">1</th>
             </tr>
-            <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e126">Scenario for testing function normalize-uri</a></th>
+            <tr class="successful">
+               <th><a href="#d4e126">Scenario for testing function normalize-uri</a></th>
+               <th class="result">42</th>
                <th class="result">0</th>
+               <th class="result">0</th>
+               <th class="result">42</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#d4e1026">Scenario for testing function relativize-uri</a></th>
+               <th class="result">20</th>
+               <th class="result">0</th>
+               <th class="result">0</th>
+               <th class="result">20</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#d4e1502">Scenario for testing function normalize-path</a></th>
                <th class="result">1</th>
+               <th class="result">0</th>
                <th class="result">0</th>
                <th class="result">1</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e143">Scenario for testing function relativize-uri</a></th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-            </tr>
-            <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e162">Scenario for testing function normalize-path</a></th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-            </tr>
-            <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e179">Scenario for testing function relativize-path</a></th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-            </tr>
-            <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e199">Scenario for testing function longest-common-uri</a></th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-            </tr>
-            <tr class="failed">
-               <th><a href="#d4e216">Scenario for testing function percent-decode</a></th>
-               <th class="result">10</th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-               <th class="result">11</th>
-            </tr>
-            <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e457">Scenario for testing function f:percent-decode</a></th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-               <th class="result">0</th>
-               <th class="result">1</th>
-            </tr>
-            <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e476">Scenario for testing function hex-to-dec</a></th>
+               <th>(<strong>Not yet implemented</strong>) <a href="#d4e1534">Scenario for testing function relativize-path</a></th>
                <th class="result">0</th>
                <th class="result">1</th>
                <th class="result">0</th>
                <th class="result">1</th>
             </tr>
             <tr class="successful">
-               <th><a href="#d4e493">Scenario for testing function unescape-uri</a></th>
+               <th><a href="#d4e1554">Scenario for testing function longest-common-uri</a></th>
+               <th class="result">10</th>
+               <th class="result">0</th>
+               <th class="result">0</th>
+               <th class="result">10</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#d4e1777">Scenario for testing function percent-decode</a></th>
+               <th class="result">10</th>
+               <th class="result">0</th>
+               <th class="result">1</th>
+               <th class="result">11</th>
+            </tr>
+            <tr class="pending">
+               <th>(<strong>Not yet implemented</strong>) <a href="#d4e2018">Scenario for testing function f:percent-decode</a></th>
+               <th class="result">0</th>
+               <th class="result">1</th>
+               <th class="result">0</th>
+               <th class="result">1</th>
+            </tr>
+            <tr class="pending">
+               <th>(<strong>Not yet implemented</strong>) <a href="#d4e2037">Scenario for testing function hex-to-dec</a></th>
+               <th class="result">0</th>
+               <th class="result">1</th>
+               <th class="result">0</th>
+               <th class="result">1</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#d4e2054">Scenario for testing function unescape-uri</a></th>
                <th class="result">11</th>
                <th class="result">0</th>
                <th class="result">0</th>
                <th class="result">11</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>Not yet implemented</strong>) <a href="#d4e734">Scenario for testing function utf8-decode</a></th>
+               <th>(<strong>Not yet implemented</strong>) <a href="#d4e2295">Scenario for testing function utf8-decode</a></th>
                <th class="result">0</th>
                <th class="result">1</th>
                <th class="result">0</th>
@@ -146,9 +146,661 @@
             </tr>
          </tbody>
       </table>
-      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e216">
+      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e126">
+         <h2 class="successful">Scenario for testing function normalize-uri<span class="scenario-totals">passed:42 / pending:0 / failed:0 / total:42</span></h2>
+         <table class="xspec" id="t-d4e126">
+            <col width="80%" />
+            <col width="20%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for testing function normalize-uri</th>
+                  <th>passed:42 / pending:0 / failed:0 / total:42</th>
+               </tr>
+               <tr class="successful">
+                  <th>The scheme and host components of the URL are case-insensitive</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>Converting the scheme and host to lower case</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>All letters within a percent-encoding triplet (e.g., "%3A") are case-insensitive,
+                     and should be capitalized
+                  </th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>Capitalizing letters in escape sequences</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>For consistency, percent-encoded octets in the ranges of ALPHA (%41–%5A and %61–%7A),
+                     DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should
+                     not be created by URI producers and, when found in a URI, should be decoded to their
+                     corresponding unreserved characters by URI normalizers
+                  </th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>Decoding percent-encoded octets of unreserved characters</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>The default port (port 80 for the “http” scheme) may be removed from (or added to)
+                     a URL
+                  </th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>Removing the default port</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>The segments “..” and “.” can be removed from a URL according to the algorithm described
+                     in RFC 3986 (or a similar algorithm)
+                  </th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>Removing dot-segments</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>Space and invalid characters</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>empty</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>Space and invalid characters</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>only spaces</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>Space and invalid characters</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>space padded</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>Space and invalid characters</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>inlined space</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>Space and invalid characters</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>percent encoded space</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>URI components are kept</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>query</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>URI components are kept</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>mailto</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>URI components are kept</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>no trailing slash</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>URI components are kept</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>single trailing slash</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>empty authority is removed</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>file uri with no path</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>empty authority is removed</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>file uri with directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>'/' normalization</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>multiple slashes</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - single dot</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>single dot</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - single dot</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>in current dir</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - single dot</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two single dots</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - single dot</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>trailing dot in absolute path</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - single dot</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>trailing dot in relative path</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - single dot</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two trailing single dots</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - single dot</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>multiple inline single dots</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>three inline dots</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>three dots only</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two dots only</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory of current directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>dot in parent directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory of '...'-directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory of subdirectory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>sibling directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>sibling directory of grandparent directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>grandparent directory of grandchild directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory of child directory with trailing slash</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory of the current directory relative to child directory with trailing
+                     slash
+                  </td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory of dot relative to parent directory of child directory with trailing
+                     slash
+                  </td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>grandparent directory of directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>parent directory of absolute top level directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>dot segment normalization - multiple dots</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>grandparent directory of child directory of absolute top level directory</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>multiple dots and slashes</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>grandchild directory with multipls dots and slashes</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e1026">
+         <h2 class="successful">Scenario for testing function relativize-uri<span class="scenario-totals">passed:20 / pending:0 / failed:0 / total:20</span></h2>
+         <table class="xspec" id="t-d4e1026">
+            <col width="80%" />
+            <col width="20%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for testing function relativize-uri</th>
+                  <th>passed:20 / pending:0 / failed:0 / total:20</th>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #1</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #2</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #3</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #4</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #5</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #6</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #7</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #8</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #9</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #10</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #11</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #12</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #13</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #14</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #15</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #16</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #17</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #18</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #19</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>relativize uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>test #20</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e1502">
+         <h2 class="successful">Scenario for testing function normalize-path<span class="scenario-totals">passed:1 / pending:0 / failed:0 / total:1</span></h2>
+         <table class="xspec" id="t-d4e1502">
+            <col width="80%" />
+            <col width="20%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for testing function normalize-path</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <th>The segments “..” and “.” can be removed from a path according to the algorithm described
+                     in RFC 3986 (or a similar algorithm)
+                  </th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>Removing dot-segments</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e1554">
+         <h2 class="successful">Scenario for testing function longest-common-uri<span class="scenario-totals">passed:10 / pending:0 / failed:0 / total:10</span></h2>
+         <table class="xspec" id="t-d4e1554">
+            <col width="80%" />
+            <col width="20%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for testing function longest-common-uri</th>
+                  <th>passed:10 / pending:0 / failed:0 / total:10</th>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two absolute uris</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two absolute uris #2</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two relative uris</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two relative uris #2</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two relative uris #3</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two absolute uris with different schemes</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two identical absolute uris</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two absolute uris that normalize to the same uri</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>two absolute uris #3</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>longest common uri</th>
+                  <th>passed:1 / pending:0 / failed:0 / total:1</th>
+               </tr>
+               <tr class="successful">
+                  <td>three absolute uris</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e1777">
          <h2 class="successful">Scenario for testing function percent-decode<span class="scenario-totals">passed:10 / pending:0 / failed:1 / total:11</span></h2>
-         <table class="xspec" id="t-d4e216">
+         <table class="xspec" id="t-d4e1777">
             <col width="80%" />
             <col width="20%" />
             <tbody>
@@ -221,11 +873,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#d4e392">unicode decode</a></th>
+                  <th><a href="#d4e1953">unicode decode</a></th>
                   <th>passed:0 / pending:0 / failed:1 / total:1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#d4e404">unicode decode</a></td>
+                  <td><a href="#d4e1965">unicode decode</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="successful">
@@ -246,8 +898,8 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="d4e392">Scenario for testing function percent-decode unicode decode</h3>
-         <h4 id="d4e404">unicode decode</h4>
+         <h3 id="d4e1953">Scenario for testing function percent-decode unicode decode</h3>
+         <h4 id="d4e1965">unicode decode</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -263,9 +915,9 @@
             </tbody>
          </table>
       </div>
-      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e493">
+      <div xmlns:oxy="http://www.oxygenxml.com/xslt/xspec" id="d4e2054">
          <h2 class="successful">Scenario for testing function unescape-uri<span class="scenario-totals">passed:11 / pending:0 / failed:0 / total:11</span></h2>
-         <table class="xspec" id="t-d4e493">
+         <table class="xspec" id="t-d4e2054">
             <col width="80%" />
             <col width="20%" />
             <tbody>

--- a/file-utils/src/test/uri-functions.xspec
+++ b/file-utils/src/test/uri-functions.xspec
@@ -52,26 +52,359 @@
         <x:expect label="Not yet implemented" select="'Not yet implemented'"/>
     </x:scenario>
 
-    <x:scenario pending="Not yet implemented" label="Scenario for testing function normalize-uri">
+    <x:scenario label="Scenario for testing function normalize-uri">
         <x:call function="pf:normalize-uri">
             <x:param name="uri" select="''"/>
         </x:call>
-        <x:expect label="Not yet implemented" select="'Not yet implemented'"/>
+        <x:scenario label="The scheme and host components of the URL are case-insensitive">
+            <x:call>
+                <x:param name="uri" select="'HTTP://www.Example.com/'"/>
+            </x:call>
+            <x:expect label="Converting the scheme and host to lower case" select="'http://www.example.com/'"/>
+        </x:scenario>
+        <x:scenario label="All letters within a percent-encoding triplet (e.g., &quot;%3A&quot;) are case-insensitive, and should be capitalized">
+            <x:call>
+                <x:param name="uri" select="'http://www.example.com/a%c2%b1b'"/>
+            </x:call>
+            <x:expect label="Capitalizing letters in escape sequences" select="'http://www.example.com/a%C2%B1b'"/>
+        </x:scenario>
+        <x:scenario label="For consistency, percent-encoded octets in the ranges of ALPHA (%41–%5A and %61–%7A), DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers and, when found in a URI, should be decoded to their corresponding unreserved characters by URI normalizers">
+            <x:call>
+                <x:param name="uri" select="'http://www.example.com/%7Eusername/'"/>
+            </x:call>
+            <x:expect label="Decoding percent-encoded octets of unreserved characters" select="'http://www.example.com/~username/'"/>
+        </x:scenario>
+        <x:scenario label="The default port (port 80 for the “http” scheme) may be removed from (or added to) a URL">
+            <x:call>
+                <x:param name="uri" select="'http://www.example.com:80/bar.html'"/>
+            </x:call>
+            <x:expect label="Removing the default port" select="'http://www.example.com/bar.html'"/>
+        </x:scenario>
+        <x:scenario label="The segments “..” and “.” can be removed from a URL according to the algorithm described in RFC 3986 (or a similar algorithm)">
+            <x:call>
+                <x:param name="uri" select="'http://www.example.com/../a/b/../c/./d.html'"/>
+            </x:call>
+            <x:expect label="Removing dot-segments" select="'http://www.example.com/a/c/d.html'"/>
+        </x:scenario>
+        
+        <!-- from UTF-X test document -->
+        <x:scenario label="Space and invalid characters">
+            <x:call><x:param name="uri" select="''"/></x:call>
+            <x:expect label="empty" select="''"/>
+        </x:scenario>
+        <!-- Space and invalid characters-->
+        <x:scenario label="Space and invalid characters">
+            <x:call><x:param name="uri" select="'  '"/></x:call>
+            <x:expect label="only spaces" select="''"/>
+        </x:scenario>
+        <x:scenario label="Space and invalid characters">
+            <x:call><x:param name="uri" select="'  http://www.google.com  '"/></x:call>
+            <x:expect label="space padded" select="'http://www.google.com'"/>
+        </x:scenario>
+        <x:scenario label="Space and invalid characters">
+            <x:call><x:param name="uri" select="'  http://www.ex ample.com  '"/></x:call>
+            <x:expect label="inlined space" select="'http://www.ex%20ample.com'"/>
+        </x:scenario>
+        <x:scenario label="Space and invalid characters">
+            <x:call><x:param name="uri" select="'http://www.ex%20ample.com'"/></x:call>
+            <x:expect label="percent encoded space" select="'http://www.ex%20ample.com'"/>
+        </x:scenario>
+        <!-- URI components are kept -->
+        <x:scenario label="URI components are kept">
+            <x:call><x:param name="uri" select="'file.xml?q=a#id'"/></x:call>
+            <x:expect label="query" select="'file.xml?q=a#id'"/>
+        </x:scenario>
+        <x:scenario label="URI components are kept">
+            <x:call><x:param name="uri" select="'mailto:johndoe@example.org'"/></x:call>
+            <x:expect label="mailto" select="'mailto:johndoe@example.org'"/>
+        </x:scenario>
+        <x:scenario label="URI components are kept">
+            <x:call><x:param name="uri" select="'http://www.google.com'"/></x:call>
+            <x:expect label="no trailing slash" select="'http://www.google.com'"/>
+        </x:scenario>
+        <x:scenario label="URI components are kept">
+            <x:call><x:param name="uri" select="'http://www.google.com/'"/></x:call>
+            <x:expect label="single trailing slash" select="'http://www.google.com/'"/>
+        </x:scenario>
+        <!-- empty authority is removed -->
+        <x:scenario label="empty authority is removed">
+            <x:call><x:param name="uri" select="'file:///'"/></x:call>
+            <x:expect label="file uri with no path" select="'file:/'"/>
+        </x:scenario>
+        <x:scenario label="empty authority is removed">
+            <x:call><x:param name="uri" select="'file:///dir/'"/></x:call>
+            <x:expect label="file uri with directory" select="'file:/dir/'"/>
+        </x:scenario>
+        <!-- '/' normalization -->
+        <x:scenario label="'/' normalization">
+            <x:call><x:param name="uri" select="'////dir////sub///'"/></x:call>
+            <x:expect label="multiple slashes" select="'/dir/sub/'"/>
+        </x:scenario>
+        <!-- dot segment normalization -->
+        <x:scenario label="dot segment normalization - single dot">
+            <x:call><x:param name="uri" select="'.'"/></x:call>
+            <x:expect label="single dot" select="''"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - single dot">
+            <x:call><x:param name="uri" select="'./dir'"/></x:call>
+            <x:expect label="in current dir" select="'dir'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - single dot">
+            <x:call><x:param name="uri" select="'././dir'"/></x:call>
+            <x:expect label="two single dots" select="'dir'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - single dot">
+            <x:call><x:param name="uri" select="'/.'"/></x:call>
+            <x:expect label="trailing dot in absolute path" select="'/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - single dot">
+            <x:call><x:param name="uri" select="'dir/.'"/></x:call>
+            <x:expect label="trailing dot in relative path" select="'dir/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - single dot">
+            <x:call><x:param name="uri" select="'dir/./.'"/></x:call>
+            <x:expect label="two trailing single dots" select="'dir/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - single dot">
+            <x:call><x:param name="uri" select="'dir/./././sub/'"/></x:call>
+            <x:expect label="multiple inline single dots" select="'dir/sub/'"/>
+        </x:scenario>
+        <!-- '..' normalization -->
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/.../sub'"/></x:call>
+            <x:expect label="three inline dots" select="'dir/.../sub'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'...'"/></x:call>
+            <x:expect label="three dots only" select="'...'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'..'"/></x:call>
+            <x:expect label="two dots only" select="'../'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'./..'"/></x:call>
+            <x:expect label="parent directory of current directory" select="'../'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'../.'"/></x:call>
+            <x:expect label="dot in parent directory" select="'../'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'.../..'"/></x:call>
+            <x:expect label="parent directory of '...'-directory" select="''"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/..'"/></x:call>
+            <x:expect label="parent directory" select="''"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/sub/..'"/></x:call>
+            <x:expect label="parent directory of subdirectory" select="'dir/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/../other/'"/></x:call>
+            <x:expect label="sibling directory" select="'other/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/dir/../../other/'"/></x:call>
+            <x:expect label="sibling directory of grandparent directory" select="'other/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/sub/sub/../..'"/></x:call>
+            <x:expect label="grandparent directory of grandchild directory" select="'dir/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/sub/../'"/></x:call>
+            <x:expect label="parent directory of child directory with trailing slash" select="'dir/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/sub/./../'"/></x:call>
+            <x:expect label="parent directory of the current directory relative to child directory with trailing slash" select="'dir/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/sub/.././../'"/></x:call>
+            <x:expect label="parent directory of dot relative to parent directory of child directory with trailing slash" select="''"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'dir/../..'"/></x:call>
+            <x:expect label="grandparent directory of directory" select="'../'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'/..'"/></x:call>
+            <x:expect label="parent directory of absolute top level directory" select="'/'"/>
+        </x:scenario>
+        <x:scenario label="dot segment normalization - multiple dots">
+            <x:call><x:param name="uri" select="'/dir/../..'"/></x:call>
+            <x:expect label="grandparent directory of child directory of absolute top level directory" select="'/'"/>
+        </x:scenario>
+        <!-- normalization combined -->
+        <x:scenario label="multiple dots and slashes">
+            <x:call><x:param name="uri" select="'///././//dir////sub///'"/></x:call>
+            <x:expect label="grandchild directory with multipls dots and slashes" select="'/dir/sub/'"/>
+        </x:scenario>
     </x:scenario>
 
-    <x:scenario pending="Not yet implemented" label="Scenario for testing function relativize-uri">
+    <x:scenario label="Scenario for testing function relativize-uri">
         <x:call function="pf:relativize-uri">
             <x:param name="uri" select="''"/>
             <x:param name="base" select="''"/>
         </x:call>
-        <x:expect label="Not yet implemented" select="'Not yet implemented'"/>
+        
+        <!-- from UTF-X test document -->
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'file:/dir/'"/>
+            </x:call>
+            <x:expect label="test #1" select="'file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'file:/dir/otherfile.xml'"/>
+            </x:call>
+            <x:expect label="test #2" select="'file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'file:/dir/otherfile.xml#fragment'"/>
+            </x:call>
+            <x:expect label="test #3" select="'file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'file:/dir/file.xml'"/>
+            </x:call>
+            <x:expect label="test #4" select="'file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml#fragment'"/>
+                <x:param name="base" select="'file:/dir/'"/>
+            </x:call>
+            <x:expect label="test #5" select="'file.xml#fragment'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'file:/dir'"/>
+            </x:call>
+            <x:expect label="test #6" select="'dir/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'file:/'"/>
+            </x:call>
+            <x:expect label="test #7" select="'dir/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/file.xml'"/>
+                <x:param name="base" select="'file:/'"/>
+            </x:call>
+            <x:expect label="test #8" select="'file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'file:/dir/sub/'"/>
+            </x:call>
+            <x:expect label="test #9" select="'../file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/sub/file.xml'"/>
+                <x:param name="base" select="'file:/dir/other/other/'"/>
+            </x:call>
+            <x:expect label="test #10" select="'../../sub/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/sub/file.xml'"/>
+                <x:param name="base" select="'file:/dir/other/other/file.xml'"/>
+            </x:call>
+            <x:expect label="test #11" select="'../../sub/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/sub/file.xml'"/>
+                <x:param name="base" select="'file:/dir/'"/>
+            </x:call>
+            <x:expect label="test #12" select="'sub/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/anydir/../anyother/sub/../../thedir/file.xml'"/>
+                <x:param name="base" select="'file:/dir/sub/sub/'"/>
+            </x:call>
+            <x:expect label="test #13" select="'../../thedir/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'http://example.org/file.xml'"/>
+                <x:param name="base" select="'file:/dir/'"/>
+            </x:call>
+            <x:expect label="test #14" select="'http://example.org/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'http://example.org/file.xml'"/>
+                <x:param name="base" select="'http://example.net/'"/>
+            </x:call>
+            <x:expect label="test #15" select="'http://example.org/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'file:/dir/file.xml'"/>
+                <x:param name="base" select="'relative/'"/>
+            </x:call>
+            <x:expect label="test #16" select="'file:/dir/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'relative/file.xml'"/>
+                <x:param name="base" select="'file:/home/user/dir/'"/>
+            </x:call>
+            <x:expect label="test #17" select="'relative/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="'../relative/file.xml'"/>
+                <x:param name="base" select="'file:/home/user/dir/'"/>
+            </x:call>
+            <x:expect label="test #18" select="'../relative/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="''"/>
+                <x:param name="base" select="'file:/dir/'"/>
+            </x:call>
+            <x:expect label="test #19" select="''"/>
+        </x:scenario>
+        <x:scenario label="relativize uri">
+            <x:call>
+                <x:param name="uri" select="''"/>
+                <x:param name="base" select="''"/>
+            </x:call>
+            <x:expect label="test #20" select="''"/>
+        </x:scenario>
     </x:scenario>
 
-    <x:scenario pending="Not yet implemented" label="Scenario for testing function normalize-path">
+    <x:scenario label="Scenario for testing function normalize-path">
         <x:call function="pf:normalize-path">
             <x:param name="path" select="''"/>
         </x:call>
-        <x:expect label="Not yet implemented" select="'Not yet implemented'"/>
+        
+        <x:scenario label="The segments “..” and “.” can be removed from a path according to the algorithm described in RFC 3986 (or a similar algorithm)">
+            <x:call>
+                <x:param name="path" select="'/../a/b/../c/./d.html'"/>
+            </x:call>
+            <x:expect label="Removing dot-segments" select="'/a/c/d.html'"/>
+        </x:scenario>
     </x:scenario>
 
     <x:scenario pending="Not yet implemented" label="Scenario for testing function relativize-path">
@@ -82,11 +415,52 @@
         <x:expect label="Not yet implemented" select="'Not yet implemented'"/>
     </x:scenario>
 
-    <x:scenario pending="Not yet implemented" label="Scenario for testing function longest-common-uri">
+    <x:scenario label="Scenario for testing function longest-common-uri">
         <x:call function="pf:longest-common-uri">
             <x:param name="uris" select="''"/>
         </x:call>
-        <x:expect label="Not yet implemented" select="'Not yet implemented'"/>
+        
+        <!-- from UTF-X test document -->
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('file:/tmp/home/user/dir1/dir2/file.xml', 'file:/tmp/home/user/dir3/dir4')"/></x:call>
+            <x:expect label="two absolute uris" select="'file:/tmp/home/user/'"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('file:/tmp/home/user/dir1/dir2/file.xml', 'file:/tmp/home/user/dir1/dir2/file.xml')"/></x:call>
+            <x:expect label="two absolute uris #2" select="'file:/tmp/home/user/dir1/dir2/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('dir1/dir2/file.xml', 'dir1/dir4')"/></x:call>
+            <x:expect label="two relative uris" select="'dir1/'"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('dir1/dir2/file.xml', 'dir3/dir4')"/></x:call>
+            <x:expect label="two relative uris #2" select="''"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('dir1/dir2/file.xml', 'dir1/dir2/file.xml')"/></x:call>
+            <x:expect label="two relative uris #3" select="'dir1/dir2/file.xml'"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('http://www.example.com/', 'file:/tmp/home/user/')"/></x:call>
+            <x:expect label="two absolute uris with different schemes" select="''"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('http://www.example.com/', 'http://www.example.com/')"/></x:call>
+            <x:expect label="two identical absolute uris" select="'http://www.example.com/'"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('http:///www.example.com/', 'http://///www.example.com//')"/></x:call>
+            <x:expect label="two absolute uris that normalize to the same uri" select="'http://www.example.com/'"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('file:/tmp/home/user/dir1', 'file://tmp/home/user/dir2')"/></x:call>
+            <x:expect label="two absolute uris #3" select="'file:/tmp/home/user/'"/>
+        </x:scenario>
+        <x:scenario label="longest common uri">
+            <x:call><x:param name="uris" select="('file:/tmp/home/user/dir1/dir2/file.xml', 'file:/tmp/home/user/dir2/dir3', 'file:/tmp/home/user/dir4/dir5')"/></x:call>
+            <x:expect label="three absolute uris" select="'file:/tmp/home/user/'"/>
+        </x:scenario>
     </x:scenario>
 
     <x:scenario label="Scenario for testing function percent-decode">


### PR DESCRIPTION
Without URL-normalization, px:fileset-add-entry couldn't add 8.3-formatted
Windows-filenames. For instance, "Documents and Settings" becomes
"DOCUME~1", which wasn't recognized as the same as "DOCUME%7E1"
in pf:relativize-uri.
