### PR TITLE
px:mediatype-detect is very slow for large filesets

### DIFF
--- a/mediatype-utils/src/main/resources/xml/xproc/mediatype.xpl
+++ b/mediatype-utils/src/main/resources/xml/xproc/mediatype.xpl
@@ -39,645 +39,225 @@
         <p:input port="source"/>
         <p:output port="result"/>
         <p:variable name="ext" select="lower-case(replace(/*/@href,'^.+?([^/\.]+)$','$1'))"/>
-        <p:choose>
-            <p:when test="$ext = 'xml'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xml"/>
-            </p:when>
-            <p:when test="$ext = 'xhtml'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xhtml+xml"/>
-            </p:when>
-            <p:when test="$ext = 'smil'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ext = 'mp3'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/mpeg"/>
-            </p:when>
-            <p:when test="$ext = 'epub'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/epub+zip"/>
-            </p:when>
-            <p:when test="$ext = 'xpl'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xproc+xml"/>
-            </p:when>
-            <p:when test="$ext = 'xproc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xproc+xml"/>
-            </p:when>
-            <p:when test="$ext = 'xsl'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xslt+xml"/>
-            </p:when>
-            <p:when test="$ext = 'xslt'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xslt+xml"/>
-            </p:when>
-            <p:when test="$ext = 'xq'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xquery+xml"/>
-            </p:when>
-            <p:when test="$ext = 'xquery'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xquery+xml"/>
-            </p:when>
-            <p:when test="$ext = 'otf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-font-opentype"/>
-            </p:when>
-            <p:when test="$ext = 'wav'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/x-wav"/>
-            </p:when>
-            <p:when test="$ext = 'opf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/oebps-package+xml"/>
-            </p:when>
-            <p:when test="$ext = 'ncx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-dtbncx+xml"/>
-            </p:when>
-            <p:when test="$ext = 'mp4'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/mpeg4-generic"/>
-            </p:when>
-            <p:when test="$ext = 'jpg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/jpeg"/>
-            </p:when>
-            <p:when test="$ext = 'jpe'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/jpeg"/>
-            </p:when>
-            <p:when test="$ext = 'jpeg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/jpeg"/>
-            </p:when>
-            <p:when test="$ext = 'png'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/png"/>
-            </p:when>
-            <p:when test="$ext = 'svg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/svg+xml"/>
-            </p:when>
-            <p:when test="$ext = 'css'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/css"/>
-            </p:when>
-            <p:when test="$ext = 'dtd'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xml-dtd"/>
-            </p:when>
-            <p:when test="$ext = 'res'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-dtbresource+xml"/>
-            </p:when>
-            <p:when test="$ext = 'ogg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/ogg"/>
-            </p:when>
-            <p:when test="$ext = 'au'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/basic"/>
-            </p:when>
-            <p:when test="$ext = 'snd'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/basic"/>
-            </p:when>
-            <p:when test="$ext = 'mid'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/mid"/>
-            </p:when>
-            <p:when test="$ext = 'rmi'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/mid"/>
-            </p:when>
-            <p:when test="$ext = 'aif'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/x-aiff"/>
-            </p:when>
-            <p:when test="$ext = 'aifc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/x-aiff"/>
-            </p:when>
-            <p:when test="$ext = 'aiff'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/x-aiff"/>
-            </p:when>
-            <p:when test="$ext = 'm3u'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/x-mpegurl"/>
-            </p:when>
-            <p:when test="$ext = 'ra'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/x-pn-realaudio"/>
-            </p:when>
-            <p:when test="$ext = 'ram'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="audio/x-pn-realaudio"/>
-            </p:when>
-            <p:when test="$ext = 'bmp'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/bmp"/>
-            </p:when>
-            <p:when test="$ext = 'cod'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/cis-cod"/>
-            </p:when>
-            <p:when test="$ext = 'gif'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/gif"/>
-            </p:when>
-            <p:when test="$ext = 'ief'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/ief"/>
-            </p:when>
-            <p:when test="$ext = 'jfif'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/pipeg"/>
-            </p:when>
-            <p:when test="$ext = 'tif'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/tiff"/>
-            </p:when>
-            <p:when test="$ext = 'tiff'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/tiff"/>
-            </p:when>
-            <p:when test="$ext = 'ras'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-cmu-raster"/>
-            </p:when>
-            <p:when test="$ext = 'cmx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-cmx"/>
-            </p:when>
-            <p:when test="$ext = 'ico'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-icon"/>
-            </p:when>
-            <p:when test="$ext = 'pnm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-portable-anymap"/>
-            </p:when>
-            <p:when test="$ext = 'pbm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-portable-bitmap"/>
-            </p:when>
-            <p:when test="$ext = 'pgm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-portable-graymap"/>
-            </p:when>
-            <p:when test="$ext = 'ppm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-portable-pixmap"/>
-            </p:when>
-            <p:when test="$ext = 'rgb'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-rgb"/>
-            </p:when>
-            <p:when test="$ext = 'xbm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-xbitmap"/>
-            </p:when>
-            <p:when test="$ext = 'xpm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-xpixmap"/>
-            </p:when>
-            <p:when test="$ext = 'xwd'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/x-xwindowdump"/>
-            </p:when>
-            <p:when test="$ext = 'mp2'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/mpeg"/>
-            </p:when>
-            <p:when test="$ext = 'mpa'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/mpeg"/>
-            </p:when>
-            <p:when test="$ext = 'mpe'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/mpeg"/>
-            </p:when>
-            <p:when test="$ext = 'mpeg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/mpeg"/>
-            </p:when>
-            <p:when test="$ext = 'mpg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/mpeg"/>
-            </p:when>
-            <p:when test="$ext = 'mpv2'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/mpeg"/>
-            </p:when>
-            <p:when test="$ext = 'mov'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/quicktime"/>
-            </p:when>
-            <p:when test="$ext = 'qt'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/quicktime"/>
-            </p:when>
-            <p:when test="$ext = 'lsf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/x-la-asf"/>
-            </p:when>
-            <p:when test="$ext = 'lsx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/x-la-asf"/>
-            </p:when>
-            <p:when test="$ext = 'asf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/x-ms-asf"/>
-            </p:when>
-            <p:when test="$ext = 'asr'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/x-ms-asf"/>
-            </p:when>
-            <p:when test="$ext = 'asx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/x-ms-asf"/>
-            </p:when>
-            <p:when test="$ext = 'avi'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/x-msvideo"/>
-            </p:when>
-            <p:when test="$ext = 'movie'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="video/x-sgi-movie"/>
-            </p:when>
-            <p:when test="$ext = '323'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/h323"/>
-            </p:when>
-            <p:when test="$ext = 'htm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/html"/>
-            </p:when>
-            <p:when test="$ext = 'html'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/html"/>
-            </p:when>
-            <p:when test="$ext = 'stm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/html"/>
-            </p:when>
-            <p:when test="$ext = 'uls'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/iuls"/>
-            </p:when>
-            <p:when test="$ext = 'bas'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/plain"/>
-            </p:when>
-            <p:when test="$ext = 'c'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/plain"/>
-            </p:when>
-            <p:when test="$ext = 'h'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/plain"/>
-            </p:when>
-            <p:when test="$ext = 'txt'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/plain"/>
-            </p:when>
-            <p:when test="$ext = 'rtx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/richtext"/>
-            </p:when>
-            <p:when test="$ext = 'sct'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/scriptlet"/>
-            </p:when>
-            <p:when test="$ext = 'tsv'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/tab-separated-values"/>
-            </p:when>
-            <p:when test="$ext = 'htt'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/webviewhtml"/>
-            </p:when>
-            <p:when test="$ext = 'htc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/x-component"/>
-            </p:when>
-            <p:when test="$ext = 'etx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/x-setext"/>
-            </p:when>
-            <p:when test="$ext = 'vcf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/x-vcard"/>
-            </p:when>
-            <p:when test="$ext = 'mht'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="message/rfc822"/>
-            </p:when>
-            <p:when test="$ext = 'mhtml'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="message/rfc822"/>
-            </p:when>
-            <p:when test="$ext = 'nws'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="message/rfc822"/>
-            </p:when>
-            <p:when test="$ext = 'evy'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/envoy"/>
-            </p:when>
-            <p:when test="$ext = 'fif'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/fractals"/>
-            </p:when>
-            <p:when test="$ext = 'spl'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/futuresplash"/>
-            </p:when>
-            <p:when test="$ext = 'hta'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/hta"/>
-            </p:when>
-            <p:when test="$ext = 'acx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/internet-property-stream"/>
-            </p:when>
-            <p:when test="$ext = 'hqx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/mac-binhex40"/>
-            </p:when>
-            <p:when test="$ext = 'doc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/msword"/>
-            </p:when>
-            <p:when test="$ext = 'dot'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/msword"/>
-            </p:when>
-            <p:when test="$ext = '*'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:when>
-            <p:when test="$ext = 'bin'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:when>
-            <p:when test="$ext = 'class'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:when>
-            <p:when test="$ext = 'dms'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:when>
-            <p:when test="$ext = 'exe'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:when>
-            <p:when test="$ext = 'lha'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:when>
-            <p:when test="$ext = 'lzh'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:when>
-            <p:when test="$ext = 'oda'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/oda"/>
-            </p:when>
-            <p:when test="$ext = 'axs'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/olescript"/>
-            </p:when>
-            <p:when test="$ext = 'pdf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/pdf"/>
-            </p:when>
-            <p:when test="$ext = 'prf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/pics-rules"/>
-            </p:when>
-            <p:when test="$ext = 'p10'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/pkcs10"/>
-            </p:when>
-            <p:when test="$ext = 'crl'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/pkix-crl"/>
-            </p:when>
-            <p:when test="$ext = 'ai'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/postscript"/>
-            </p:when>
-            <p:when test="$ext = 'eps'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/postscript"/>
-            </p:when>
-            <p:when test="$ext = 'ps'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/postscript"/>
-            </p:when>
-            <p:when test="$ext = 'rtf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/rtf"/>
-            </p:when>
-            <p:when test="$ext = 'setpay'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/set-payment-initiation"/>
-            </p:when>
-            <p:when test="$ext = 'setreg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/set-registration-initiation"/>
-            </p:when>
-            <p:when test="$ext = 'xla'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-excel"/>
-            </p:when>
-            <p:when test="$ext = 'xlc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-excel"/>
-            </p:when>
-            <p:when test="$ext = 'xlm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-excel"/>
-            </p:when>
-            <p:when test="$ext = 'xls'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-excel"/>
-            </p:when>
-            <p:when test="$ext = 'xlt'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-excel"/>
-            </p:when>
-            <p:when test="$ext = 'xlw'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-excel"/>
-            </p:when>
-            <p:when test="$ext = 'msg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-outlook"/>
-            </p:when>
-            <p:when test="$ext = 'sst'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-pkicertstore"/>
-            </p:when>
-            <p:when test="$ext = 'cat'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-pkiseccat"/>
-            </p:when>
-            <p:when test="$ext = 'stl'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-pkistl"/>
-            </p:when>
-            <p:when test="$ext = 'pot'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-powerpoint"/>
-            </p:when>
-            <p:when test="$ext = 'pps'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-powerpoint"/>
-            </p:when>
-            <p:when test="$ext = 'ppt'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-powerpoint"/>
-            </p:when>
-            <p:when test="$ext = 'mpp'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-project"/>
-            </p:when>
-            <p:when test="$ext = 'wcm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-works"/>
-            </p:when>
-            <p:when test="$ext = 'wdb'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-works"/>
-            </p:when>
-            <p:when test="$ext = 'wks'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-works"/>
-            </p:when>
-            <p:when test="$ext = 'wps'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/vnd.ms-works"/>
-            </p:when>
-            <p:when test="$ext = 'hlp'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/winhlp"/>
-            </p:when>
-            <p:when test="$ext = 'bcpio'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-bcpio"/>
-            </p:when>
-            <p:when test="$ext = 'cdf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-cdf"/>
-            </p:when>
-            <p:when test="$ext = 'z'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-compress"/>
-            </p:when>
-            <p:when test="$ext = 'tgz'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-compressed"/>
-            </p:when>
-            <p:when test="$ext = 'cpio'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-cpio"/>
-            </p:when>
-            <p:when test="$ext = 'csh'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-csh"/>
-            </p:when>
-            <p:when test="$ext = 'dcr'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-director"/>
-            </p:when>
-            <p:when test="$ext = 'dir'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-director"/>
-            </p:when>
-            <p:when test="$ext = 'dxr'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-director"/>
-            </p:when>
-            <p:when test="$ext = 'dvi'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-dvi"/>
-            </p:when>
-            <p:when test="$ext = 'gtar'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-gtar"/>
-            </p:when>
-            <p:when test="$ext = 'gz'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-gzip"/>
-            </p:when>
-            <p:when test="$ext = 'hdf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-hdf"/>
-            </p:when>
-            <p:when test="$ext = 'ins'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-internet-signup"/>
-            </p:when>
-            <p:when test="$ext = 'isp'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-internet-signup"/>
-            </p:when>
-            <p:when test="$ext = 'iii'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-iphone"/>
-            </p:when>
-            <p:when test="$ext = 'js'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-javascript"/>
-            </p:when>
-            <p:when test="$ext = 'latex'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-latex"/>
-            </p:when>
-            <p:when test="$ext = 'mdb'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msaccess"/>
-            </p:when>
-            <p:when test="$ext = 'crd'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-mscardfile"/>
-            </p:when>
-            <p:when test="$ext = 'clp'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msclip"/>
-            </p:when>
-            <p:when test="$ext = 'dll'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msdownload"/>
-            </p:when>
-            <p:when test="$ext = 'm13'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msmediaview"/>
-            </p:when>
-            <p:when test="$ext = 'm14'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msmediaview"/>
-            </p:when>
-            <p:when test="$ext = 'mvb'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msmediaview"/>
-            </p:when>
-            <p:when test="$ext = 'wmf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msmetafile"/>
-            </p:when>
-            <p:when test="$ext = 'mny'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msmoney"/>
-            </p:when>
-            <p:when test="$ext = 'pub'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-mspublisher"/>
-            </p:when>
-            <p:when test="$ext = 'scd'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msschedule"/>
-            </p:when>
-            <p:when test="$ext = 'trm'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-msterminal"/>
-            </p:when>
-            <p:when test="$ext = 'wri'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-mswrite"/>
-            </p:when>
-            <p:when test="$ext = 'cdf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-netcdf"/>
-            </p:when>
-            <p:when test="$ext = 'nc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-netcdf"/>
-            </p:when>
-            <p:when test="$ext = 'pma'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-perfmon"/>
-            </p:when>
-            <p:when test="$ext = 'pmc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-perfmon"/>
-            </p:when>
-            <p:when test="$ext = 'pml'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-perfmon"/>
-            </p:when>
-            <p:when test="$ext = 'pmr'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-perfmon"/>
-            </p:when>
-            <p:when test="$ext = 'pmw'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-perfmon"/>
-            </p:when>
-            <p:when test="$ext = 'p12'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs12"/>
-            </p:when>
-            <p:when test="$ext = 'pfx'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs12"/>
-            </p:when>
-            <p:when test="$ext = 'p7b'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs7-certificates"/>
-            </p:when>
-            <p:when test="$ext = 'spc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs7-certificates"/>
-            </p:when>
-            <p:when test="$ext = 'p7r'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs7-certreqresp"/>
-            </p:when>
-            <p:when test="$ext = 'p7c'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs7-mime"/>
-            </p:when>
-            <p:when test="$ext = 'p7m'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs7-mime"/>
-            </p:when>
-            <p:when test="$ext = 'p7s'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-pkcs7-signature"/>
-            </p:when>
-            <p:when test="$ext = 'sh'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-sh"/>
-            </p:when>
-            <p:when test="$ext = 'shar'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-shar"/>
-            </p:when>
-            <p:when test="$ext = 'swf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-shockwave-flash"/>
-            </p:when>
-            <p:when test="$ext = 'sit'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-stuffit"/>
-            </p:when>
-            <p:when test="$ext = 'sv4cpio'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-sv4cpio"/>
-            </p:when>
-            <p:when test="$ext = 'sv4crc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-sv4crc"/>
-            </p:when>
-            <p:when test="$ext = 'tar'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-tar"/>
-            </p:when>
-            <p:when test="$ext = 'tcl'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-tcl"/>
-            </p:when>
-            <p:when test="$ext = 'tex'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-tex"/>
-            </p:when>
-            <p:when test="$ext = 'texi'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-texinfo"/>
-            </p:when>
-            <p:when test="$ext = 'texinfo'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-texinfo"/>
-            </p:when>
-            <p:when test="$ext = 'roff'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-troff"/>
-            </p:when>
-            <p:when test="$ext = 't'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-troff"/>
-            </p:when>
-            <p:when test="$ext = 'tr'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-troff"/>
-            </p:when>
-            <p:when test="$ext = 'man'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-troff-man"/>
-            </p:when>
-            <p:when test="$ext = 'me'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-troff-me"/>
-            </p:when>
-            <p:when test="$ext = 'ms'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-troff-ms"/>
-            </p:when>
-            <p:when test="$ext = 'ustar'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-ustar"/>
-            </p:when>
-            <p:when test="$ext = 'src'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-wais-source"/>
-            </p:when>
-            <p:when test="$ext = 'cer'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-x509-ca-cert"/>
-            </p:when>
-            <p:when test="$ext = 'crt'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-x509-ca-cert"/>
-            </p:when>
-            <p:when test="$ext = 'der'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-x509-ca-cert"/>
-            </p:when>
-            <p:when test="$ext = 'pko'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/ynd.ms-pkipko"/>
-            </p:when>
-            <p:when test="$ext = 'zip'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/zip"/>
-            </p:when>
-            <p:when test="$ext = 'flr'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="x-world/x-vrml"/>
-            </p:when>
-            <p:when test="$ext = 'vrml'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="x-world/x-vrml"/>
-            </p:when>
-            <p:when test="$ext = 'wrl'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="x-world/x-vrml"/>
-            </p:when>
-            <p:when test="$ext = 'wrz'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="x-world/x-vrml"/>
-            </p:when>
-            <p:when test="$ext = 'xaf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="x-world/x-vrml"/>
-            </p:when>
-            <p:when test="$ext = 'xof'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="x-world/x-vrml"/>
-            </p:when>
-            <p:when test="$ext = 'gitignore'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/plain"/>
-            </p:when>
-            <p:when test="$ext = 'hgignore'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="text/plain"/>
-            </p:when>
-            <p:otherwise>
-                <!-- unknown file extension; assume binary -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/octet-stream"/>
-            </p:otherwise>
-        </p:choose>
+        <p:add-attribute match="/*" attribute-name="media-type">
+            <p:with-option name="attribute-value" select="(//entry[@key=$ext]/@value, 'application/octet-stream')[1]">
+                <p:inline>
+                    <map>
+                        <entry key="xml"       value="application/xml"/>
+                        <entry key="xhtml"     value="application/xhtml+xml"/>
+                        <entry key="smil"      value="application/smil+xml"/>
+                        <entry key="mp3"       value="audio/mpeg"/>
+                        <entry key="epub"      value="application/epub+zip"/>
+                        <entry key="xpl"       value="application/xproc+xml"/>
+                        <entry key="xproc"     value="application/xproc+xml"/>
+                        <entry key="xsl"       value="application/xslt+xml"/>
+                        <entry key="xslt"      value="application/xslt+xml"/>
+                        <entry key="xq"        value="application/xquery+xml"/>
+                        <entry key="xquery"    value="application/xquery+xml"/>
+                        <entry key="otf"       value="application/x-font-opentype"/>
+                        <entry key="wav"       value="audio/x-wav"/>
+                        <entry key="opf"       value="application/oebps-package+xml"/>
+                        <entry key="ncx"       value="application/x-dtbncx+xml"/>
+                        <entry key="mp4"       value="audio/mpeg4-generic"/>
+                        <entry key="jpg"       value="image/jpeg"/>
+                        <entry key="jpe"       value="image/jpeg"/>
+                        <entry key="jpeg"      value="image/jpeg"/>
+                        <entry key="png"       value="image/png"/>
+                        <entry key="svg"       value="image/svg+xml"/>
+                        <entry key="css"       value="text/css"/>
+                        <entry key="dtd"       value="application/xml-dtd"/>
+                        <entry key="res"       value="application/x-dtbresource+xml"/>
+                        <entry key="ogg"       value="audio/ogg"/>
+                        <entry key="au"        value="audio/basic"/>
+                        <entry key="snd"       value="audio/basic"/>
+                        <entry key="mid"       value="audio/mid"/>
+                        <entry key="rmi"       value="audio/mid"/>
+                        <entry key="aif"       value="audio/x-aiff"/>
+                        <entry key="aifc"      value="audio/x-aiff"/>
+                        <entry key="aiff"      value="audio/x-aiff"/>
+                        <entry key="m3u"       value="audio/x-mpegurl"/>
+                        <entry key="ra"        value="audio/x-pn-realaudio"/>
+                        <entry key="ram"       value="audio/x-pn-realaudio"/>
+                        <entry key="bmp"       value="image/bmp"/>
+                        <entry key="cod"       value="image/cis-cod"/>
+                        <entry key="gif"       value="image/gif"/>
+                        <entry key="ief"       value="image/ief"/>
+                        <entry key="jfif"      value="image/pipeg"/>
+                        <entry key="tif"       value="image/tiff"/>
+                        <entry key="tiff"      value="image/tiff"/>
+                        <entry key="ras"       value="image/x-cmu-raster"/>
+                        <entry key="cmx"       value="image/x-cmx"/>
+                        <entry key="ico"       value="image/x-icon"/>
+                        <entry key="pnm"       value="image/x-portable-anymap"/>
+                        <entry key="pbm"       value="image/x-portable-bitmap"/>
+                        <entry key="pgm"       value="image/x-portable-graymap"/>
+                        <entry key="ppm"       value="image/x-portable-pixmap"/>
+                        <entry key="rgb"       value="image/x-rgb"/>
+                        <entry key="xbm"       value="image/x-xbitmap"/>
+                        <entry key="xpm"       value="image/x-xpixmap"/>
+                        <entry key="xwd"       value="image/x-xwindowdump"/>
+                        <entry key="mp2"       value="video/mpeg"/>
+                        <entry key="mpa"       value="video/mpeg"/>
+                        <entry key="mpe"       value="video/mpeg"/>
+                        <entry key="mpeg"      value="video/mpeg"/>
+                        <entry key="mpg"       value="video/mpeg"/>
+                        <entry key="mpv2"      value="video/mpeg"/>
+                        <entry key="mov"       value="video/quicktime"/>
+                        <entry key="qt"        value="video/quicktime"/>
+                        <entry key="lsf"       value="video/x-la-asf"/>
+                        <entry key="lsx"       value="video/x-la-asf"/>
+                        <entry key="asf"       value="video/x-ms-asf"/>
+                        <entry key="asr"       value="video/x-ms-asf"/>
+                        <entry key="asx"       value="video/x-ms-asf"/>
+                        <entry key="avi"       value="video/x-msvideo"/>
+                        <entry key="movie"     value="video/x-sgi-movie"/>
+                        <entry key="323"       value="text/h323"/>
+                        <entry key="htm"       value="text/html"/>
+                        <entry key="html"      value="text/html"/>
+                        <entry key="stm"       value="text/html"/>
+                        <entry key="uls"       value="text/iuls"/>
+                        <entry key="bas"       value="text/plain"/>
+                        <entry key="c"         value="text/plain"/>
+                        <entry key="h"         value="text/plain"/>
+                        <entry key="txt"       value="text/plain"/>
+                        <entry key="rtx"       value="text/richtext"/>
+                        <entry key="sct"       value="text/scriptlet"/>
+                        <entry key="tsv"       value="text/tab-separated-values"/>
+                        <entry key="htt"       value="text/webviewhtml"/>
+                        <entry key="htc"       value="text/x-component"/>
+                        <entry key="etx"       value="text/x-setext"/>
+                        <entry key="vcf"       value="text/x-vcard"/>
+                        <entry key="mht"       value="message/rfc822"/>
+                        <entry key="mhtml"     value="message/rfc822"/>
+                        <entry key="nws"       value="message/rfc822"/>
+                        <entry key="evy"       value="application/envoy"/>
+                        <entry key="fif"       value="application/fractals"/>
+                        <entry key="spl"       value="application/futuresplash"/>
+                        <entry key="hta"       value="application/hta"/>
+                        <entry key="acx"       value="application/internet-property-stream"/>
+                        <entry key="hqx"       value="application/mac-binhex40"/>
+                        <entry key="doc"       value="application/msword"/>
+                        <entry key="dot"       value="application/msword"/>
+                        <entry key="*"         value="application/octet-stream"/>
+                        <entry key="bin"       value="application/octet-stream"/>
+                        <entry key="class"     value="application/octet-stream"/>
+                        <entry key="dms"       value="application/octet-stream"/>
+                        <entry key="exe"       value="application/octet-stream"/>
+                        <entry key="lha"       value="application/octet-stream"/>
+                        <entry key="lzh"       value="application/octet-stream"/>
+                        <entry key="oda"       value="application/oda"/>
+                        <entry key="axs"       value="application/olescript"/>
+                        <entry key="pdf"       value="application/pdf"/>
+                        <entry key="prf"       value="application/pics-rules"/>
+                        <entry key="p10"       value="application/pkcs10"/>
+                        <entry key="crl"       value="application/pkix-crl"/>
+                        <entry key="ai"        value="application/postscript"/>
+                        <entry key="eps"       value="application/postscript"/>
+                        <entry key="ps"        value="application/postscript"/>
+                        <entry key="rtf"       value="application/rtf"/>
+                        <entry key="setpay"    value="application/set-payment-initiation"/>
+                        <entry key="setreg"    value="application/set-registration-initiation"/>
+                        <entry key="xla"       value="application/vnd.ms-excel"/>
+                        <entry key="xlc"       value="application/vnd.ms-excel"/>
+                        <entry key="xlm"       value="application/vnd.ms-excel"/>
+                        <entry key="xls"       value="application/vnd.ms-excel"/>
+                        <entry key="xlt"       value="application/vnd.ms-excel"/>
+                        <entry key="xlw"       value="application/vnd.ms-excel"/>
+                        <entry key="msg"       value="application/vnd.ms-outlook"/>
+                        <entry key="sst"       value="application/vnd.ms-pkicertstore"/>
+                        <entry key="cat"       value="application/vnd.ms-pkiseccat"/>
+                        <entry key="stl"       value="application/vnd.ms-pkistl"/>
+                        <entry key="pot"       value="application/vnd.ms-powerpoint"/>
+                        <entry key="pps"       value="application/vnd.ms-powerpoint"/>
+                        <entry key="ppt"       value="application/vnd.ms-powerpoint"/>
+                        <entry key="mpp"       value="application/vnd.ms-project"/>
+                        <entry key="wcm"       value="application/vnd.ms-works"/>
+                        <entry key="wdb"       value="application/vnd.ms-works"/>
+                        <entry key="wks"       value="application/vnd.ms-works"/>
+                        <entry key="wps"       value="application/vnd.ms-works"/>
+                        <entry key="hlp"       value="application/winhlp"/>
+                        <entry key="bcpio"     value="application/x-bcpio"/>
+                        <entry key="cdf"       value="application/x-cdf"/>
+                        <entry key="z"         value="application/x-compress"/>
+                        <entry key="tgz"       value="application/x-compressed"/>
+                        <entry key="cpio"      value="application/x-cpio"/>
+                        <entry key="csh"       value="application/x-csh"/>
+                        <entry key="dcr"       value="application/x-director"/>
+                        <entry key="dir"       value="application/x-director"/>
+                        <entry key="dxr"       value="application/x-director"/>
+                        <entry key="dvi"       value="application/x-dvi"/>
+                        <entry key="gtar"      value="application/x-gtar"/>
+                        <entry key="gz"        value="application/x-gzip"/>
+                        <entry key="hdf"       value="application/x-hdf"/>
+                        <entry key="ins"       value="application/x-internet-signup"/>
+                        <entry key="isp"       value="application/x-internet-signup"/>
+                        <entry key="iii"       value="application/x-iphone"/>
+                        <entry key="js"        value="application/x-javascript"/>
+                        <entry key="latex"     value="application/x-latex"/>
+                        <entry key="mdb"       value="application/x-msaccess"/>
+                        <entry key="crd"       value="application/x-mscardfile"/>
+                        <entry key="clp"       value="application/x-msclip"/>
+                        <entry key="dll"       value="application/x-msdownload"/>
+                        <entry key="m13"       value="application/x-msmediaview"/>
+                        <entry key="m14"       value="application/x-msmediaview"/>
+                        <entry key="mvb"       value="application/x-msmediaview"/>
+                        <entry key="wmf"       value="application/x-msmetafile"/>
+                        <entry key="mny"       value="application/x-msmoney"/>
+                        <entry key="pub"       value="application/x-mspublisher"/>
+                        <entry key="scd"       value="application/x-msschedule"/>
+                        <entry key="trm"       value="application/x-msterminal"/>
+                        <entry key="wri"       value="application/x-mswrite"/>
+                        <entry key="cdf"       value="application/x-netcdf"/>
+                        <entry key="nc"        value="application/x-netcdf"/>
+                        <entry key="pma"       value="application/x-perfmon"/>
+                        <entry key="pmc"       value="application/x-perfmon"/>
+                        <entry key="pml"       value="application/x-perfmon"/>
+                        <entry key="pmr"       value="application/x-perfmon"/>
+                        <entry key="pmw"       value="application/x-perfmon"/>
+                        <entry key="p12"       value="application/x-pkcs12"/>
+                        <entry key="pfx"       value="application/x-pkcs12"/>
+                        <entry key="p7b"       value="application/x-pkcs7-certificates"/>
+                        <entry key="spc"       value="application/x-pkcs7-certificates"/>
+                        <entry key="p7r"       value="application/x-pkcs7-certreqresp"/>
+                        <entry key="p7c"       value="application/x-pkcs7-mime"/>
+                        <entry key="p7m"       value="application/x-pkcs7-mime"/>
+                        <entry key="p7s"       value="application/x-pkcs7-signature"/>
+                        <entry key="sh"        value="application/x-sh"/>
+                        <entry key="shar"      value="application/x-shar"/>
+                        <entry key="swf"       value="application/x-shockwave-flash"/>
+                        <entry key="sit"       value="application/x-stuffit"/>
+                        <entry key="sv4cpio"   value="application/x-sv4cpio"/>
+                        <entry key="sv4crc"    value="application/x-sv4crc"/>
+                        <entry key="tar"       value="application/x-tar"/>
+                        <entry key="tcl"       value="application/x-tcl"/>
+                        <entry key="tex"       value="application/x-tex"/>
+                        <entry key="texi"      value="application/x-texinfo"/>
+                        <entry key="texinfo"   value="application/x-texinfo"/>
+                        <entry key="roff"      value="application/x-troff"/>
+                        <entry key="t"         value="application/x-troff"/>
+                        <entry key="tr"        value="application/x-troff"/>
+                        <entry key="man"       value="application/x-troff-man"/>
+                        <entry key="me"        value="application/x-troff-me"/>
+                        <entry key="ms"        value="application/x-troff-ms"/>
+                        <entry key="ustar"     value="application/x-ustar"/>
+                        <entry key="src"       value="application/x-wais-source"/>
+                        <entry key="cer"       value="application/x-x509-ca-cert"/>
+                        <entry key="crt"       value="application/x-x509-ca-cert"/>
+                        <entry key="der"       value="application/x-x509-ca-cert"/>
+                        <entry key="pko"       value="application/ynd.ms-pkipko"/>
+                        <entry key="zip"       value="application/zip"/>
+                        <entry key="flr"       value="x-world/x-vrml"/>
+                        <entry key="vrml"      value="x-world/x-vrml"/>
+                        <entry key="wrl"       value="x-world/x-vrml"/>
+                        <entry key="wrz"       value="x-world/x-vrml"/>
+                        <entry key="xaf"       value="x-world/x-vrml"/>
+                        <entry key="xof"       value="x-world/x-vrml"/>
+                        <entry key="gitignore" value="text/plain"/>
+                        <entry key="hgignore"  value="text/plain"/>
+                    </map>
+                </p:inline>
+            </p:with-option>
+        </p:add-attribute>
     </p:declare-step>
     
     <p:declare-step type="pxi:mediatype-detect-from-namespace" name="detect-from-namespace">
@@ -687,103 +267,51 @@
         <p:variable name="ns" select="namespace-uri(/*)">
             <p:pipe port="in-memory" step="detect-from-namespace"/>
         </p:variable>
-        <p:choose>
-            <p:when test="$ns = 'http://www.w3.org/1999/xhtml'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xhtml+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.idpf.org/2007/opf'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/oebps-package+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.daisy.org/z3986/2005/dtbook/'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-dtbook+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/TR/REC-smil'">
-                <!-- SMIL 1.0 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2001/SMIL20/'">
-                <!-- SMIL 2.0 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2001/SMIL20/Language'">
-                <!-- SMIL 2.0 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2005/SMIL21/'">
-                <!-- SMIL 2.1 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2005/SMIL21/Language'">
-                <!-- SMIL 2.1 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2005/SMIL21/Mobile'">
-                <!-- SMIL 2.1 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2005/SMIL21/ExtendedMobile'">
-                <!-- SMIL 2.1 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2005/SMIL21/MobileProfile'">
-                <!-- SMIL 2.1 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2005/SMIL21/BasicExclTimeContainers'">
-                <!-- SMIL 2.1 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/ns/SMIL'">
-                <!-- SMIL 3.0 -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/smil+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.daisy.org/z3986/2005/ncx/'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/x-dtbncx+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2000/svg'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="image/svg+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/ns/xproc'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xproc+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/ns/xproc-step'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xproc+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/ns/xproc-error'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xproc+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/1999/XSL/Transform'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xslt+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/1999/XSL/Format'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.daisy.org/ns/z3986/authoring/'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/z3998-auth+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.daisy.org/ns/z3998/authoring/'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/z3998-auth+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/XML/1998/namespace'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://openebook.org/namespaces/oeb-package/1.0/'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/oebps-package+xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/2001/XML'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xml"/>
-            </p:when>
-            <p:when test="$ns = 'http://www.w3.org/ns/xproc-step'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xproc+xml"/>
-            </p:when>
-            <p:when test="$ns = 'urn:oasis:names:tc:entity:xmlns:xml:catalog'">
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xml"/>
-            </p:when>
-            <p:otherwise>
-                <!-- unknown namespace; use application/xml -->
-                <p:add-attribute match="/*" attribute-name="media-type" attribute-value="application/xml"/>
-            </p:otherwise>
-        </p:choose>
+         <p:add-attribute match="/*" attribute-name="media-type">
+            <p:with-option name="attribute-value" select="(//entry[@key=$ns]/@value, 'application/xml')[1]">
+                <p:inline>
+                    <map>
+                        <entry key="http://www.w3.org/1999/xhtml"                          value="application/xhtml+xml"/>
+                        <entry key="http://www.idpf.org/2007/opf"                          value="application/oebps-package+xml"/>
+                        <entry key="http://www.daisy.org/z3986/2005/dtbook/"               value="application/x-dtbook+xml"/>
+                        <!-- SMIL 1.0 -->
+                        <entry key="http://www.w3.org/TR/REC-smil"                         value="application/smil+xml"/>
+                        <!-- SMIL 2.0 -->
+                        <entry key="http://www.w3.org/2001/SMIL20/"                        value="application/smil+xml"/>
+                        <!-- SMIL 2.0 -->
+                        <entry key="http://www.w3.org/2001/SMIL20/Language"                value="application/smil+xml"/>
+                        <!-- SMIL 2.1 -->
+                        <entry key="http://www.w3.org/2005/SMIL21/"                        value="application/smil+xml"/>
+                        <!-- SMIL 2.1 -->
+                        <entry key="http://www.w3.org/2005/SMIL21/Language"                value="application/smil+xml"/>
+                        <!-- SMIL 2.1 -->
+                        <entry key="http://www.w3.org/2005/SMIL21/Mobile"                  value="application/smil+xml"/>
+                        <!-- SMIL 2.1 -->
+                        <entry key="http://www.w3.org/2005/SMIL21/ExtendedMobile"          value="application/smil+xml"/>
+                        <!-- SMIL 2.1 -->
+                        <entry key="http://www.w3.org/2005/SMIL21/MobileProfile"           value="application/smil+xml"/>
+                        <!-- SMIL 2.1 -->
+                        <entry key="http://www.w3.org/2005/SMIL21/BasicExclTimeContainers" value="application/smil+xml"/>
+                        <!-- SMIL 3.0 -->
+                        <entry key="http://www.w3.org/ns/SMIL"                             value="application/smil+xml"/>
+                        <entry key="http://www.daisy.org/z3986/2005/ncx/"                  value="application/x-dtbncx+xml"/>
+                        <entry key="http://www.w3.org/2000/svg"                            value="image/svg+xml"/>
+                        <entry key="http://www.w3.org/ns/xproc"                            value="application/xproc+xml"/>
+                        <entry key="http://www.w3.org/ns/xproc-step"                       value="application/xproc+xml"/>
+                        <entry key="http://www.w3.org/ns/xproc-error"                      value="application/xproc+xml"/>
+                        <entry key="http://www.w3.org/1999/XSL/Transform"                  value="application/xslt+xml"/>
+                        <entry key="http://www.w3.org/1999/XSL/Format"                     value="application/xml"/>
+                        <entry key="http://www.daisy.org/ns/z3986/authoring/"              value="application/z3998-auth+xml"/>
+                        <entry key="http://www.daisy.org/ns/z3998/authoring/"              value="application/z3998-auth+xml"/>
+                        <entry key="http://www.w3.org/XML/1998/namespace"                  value="application/xml"/>
+                        <entry key="http://openebook.org/namespaces/oeb-package/1.0/"      value="application/oebps-package+xml"/>
+                        <entry key="http://www.w3.org/2001/XML"                            value="application/xml"/>
+                        <entry key="http://www.w3.org/ns/xproc-step"                       value="application/xproc+xml"/>
+                        <entry key="urn:oasis:names:tc:entity:xmlns:xml:catalog"           value="application/xml"/>
+                    </map>
+                </p:inline>
+            </p:with-option>
+         </p:add-attribute>
     </p:declare-step>
 
     <p:viewport match="//d:file" name="file">
@@ -793,6 +321,7 @@
                 <p:identity/>
             </p:when>
             <p:otherwise>
+                <!-- check if the file is in memory -->
                 <p:group name="file-in-memory">
                     <p:output port="result"/>
                     <p:variable name="target" select="resolve-uri(/*/@href,base-uri(/*))"/>


### PR DESCRIPTION
This is an attempt to improve on that. A further optimization
could be to completely bypass the 'detect-from-namespace' parts
when 'in-memory' is empty and 'load-if-not-in-memory' is false.

@josteinaj Do these changes make sense? I've tried to run the tests but they failed already before I did the change. So I'm not sure I didn't break anything.

Btw, I have two other commits, if you want I'll push them:
1. one where I changed the giant p:choose into a single p:add-attribute + an inline XML document with the mappings between extension and mediatype. (Initially because I thought the p:choose was causing the issue, and now because it makes everything a bit more compact and easier to read.)
2. one where I run the tests from Maven, using my xproc-maven-plugin.
