### PR TITLE
relative hrefs are always prefixed with / in fileset-filter

### DIFF
--- a/fileset-utils/src/main/resources/xml/xproc/fileset-filter.xpl
+++ b/fileset-utils/src/main/resources/xml/xproc/fileset-filter.xpl
@@ -25,7 +25,7 @@
         <p:otherwise>
             <p:variable name="href-regex" select="concat('^',replace(replace(replace($href,'([\[\^\.\\\+\{\}\(\)\|\^\$\]])','\\$1'),'\?','.'),'\*','.*'),'$')"/>
             <p:delete>
-                <p:with-option name="match" select="concat(&quot;//d:file[not(matches('&quot;,$href-regex,&quot;','^\w+:/') and matches(resolve-uri(@href,base-uri(.)),'&quot;,$href-regex,&quot;') or matches(@href,'&quot;,$href-regex,&quot;'))]&quot;)"/>
+                <p:with-option name="match" select="concat(&quot;//d:file[not(matches('&quot;,$href-regex,&quot;','^\w+:/') and matches(resolve-uri(@href,base-uri(.)),'&quot;,$href-regex,&quot;') or matches(replace(concat('/',@href),'^/+','/'),'&quot;,$href-regex,&quot;'))]&quot;)"/>
             </p:delete>
         </p:otherwise>
     </p:choose>


### PR DESCRIPTION
this allows for easier glob filtering on filenames. for instance "*/ncc.html" meaning "any file named exactly ncc.html in any directory"
