### PR TITLE
px:fileset-store: store c:data documents as text

### DIFF
--- a/fileset-utils/src/main/resources/xml/xproc/fileset-store.xpl
+++ b/fileset-utils/src/main/resources/xml/xproc/fileset-store.xpl
@@ -69,6 +69,11 @@
                             <p:with-option name="href" select="$target"/>
                         </p:store>
                     </p:when>
+                    <p:when test="/c:data">
+                        <p:store method="text">
+                            <p:with-option name="href" select="$target"/>
+                        </p:store>
+                    </p:when>
                     <p:otherwise>
                         <p:store omit-xml-declaration="false" indent="true" encoding="UTF-8">
                             <p:with-option name="href" select="$target"/>


### PR DESCRIPTION
(except in the case of base64 encoding, but that was already handled correctly)
