### PR TITLE
px:fileset-store: don't use indent='true'

### DIFF
--- a/fileset-utils/src/main/resources/xml/xproc/fileset-store.xpl
+++ b/fileset-utils/src/main/resources/xml/xproc/fileset-store.xpl
@@ -75,7 +75,7 @@
                         </p:store>
                     </p:when>
                     <p:otherwise>
-                        <p:store omit-xml-declaration="false" indent="true" encoding="UTF-8">
+                        <p:store omit-xml-declaration="false" encoding="UTF-8">
                             <p:with-option name="href" select="$target"/>
                         </p:store>
                     </p:otherwise>


### PR DESCRIPTION
because it can be undesirable, e.g. in the case of nested inline elements:
`<span><strong>...</strong></span>`
or touching inline elements:
`<em>...</em><span>...</span>`

I don't know what effect this will have on other stuff. Maybe we could make "indent" an option to px:fileset-store?
