### PR TITLE
px:zip-load

### DIFF
--- a/zip-utils/src/main/resources/xml/xproc/unzip-fileset.xpl
+++ b/zip-utils/src/main/resources/xml/xproc/unzip-fileset.xpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step type="px:zip-load" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:d="http://www.daisy.org/ns/pipeline/data"
+<p:declare-step type="px:unzip-fileset" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:d="http://www.daisy.org/ns/pipeline/data"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc" version="1.0" name="main">
     
     <p:option name="href" required="true"/>

--- a/zip-utils/src/main/resources/xml/xproc/zip-library.xpl
+++ b/zip-utils/src/main/resources/xml/xproc/zip-library.xpl
@@ -47,6 +47,6 @@
         </p:xslt>
     </p:declare-step>
     
-    <p:import href="load.xpl"/>
+    <p:import href="unzip-fileset.xpl"/>
     
 </p:library>


### PR DESCRIPTION
I started writing a px:epub3-load step, but soon realized there was nothing epub-specific about it.

px:zip-load is a convenience wrapper around px:unzip, where you get a fileset and all the files inside the zip on the "fileset.out" and "in-memory.out" ports respectively.

To store the fileset to disk, simply use px:fileset-store.

I don't know if there's any point in providing a px:epub3-load alias...?
