### PR TITLE
allow for no reports in validation report XML

### DIFF
--- a/validation-utils/src/main/resources/xml/schema/document-validation-report.rng
+++ b/validation-utils/src/main/resources/xml/schema/document-validation-report.rng
@@ -42,9 +42,9 @@
   </define>
   <define name="reports">
     <element name="reports">
-      <oneOrMore>
+      <zeroOrMore>
         <ref name="report"/>
-      </oneOrMore>
+      </zeroOrMore>
     </element>
   </define>
   <define name="report">


### PR DESCRIPTION
When using validation steps (for instance l:relax-ng-report),
you may get an empty document sequence back. This will result
in a validation report with no "report" elements inside the
"reports" element when using px:combine-validation-reports.
I suggest we allow for this.
