### PR TITLE
don't create d:file elements for directories when unzipping

### DIFF
--- a/zip-utils/src/main/resources/xml/xproc/unzip-fileset.xpl
+++ b/zip-utils/src/main/resources/xml/xproc/unzip-fileset.xpl
@@ -25,6 +25,7 @@
         <p:with-option name="attribute-value" select="$unzipped-basedir"/>
     </p:add-attribute>
     <p:delete match="/*/@*[not(name()='xml:base')]"/>
+    <p:delete match="/*/*[ends-with(@name,'/')]"/>
     <p:viewport match="/*/*">
         <p:rename match="/*" new-name="d:file"/>
         <p:add-attribute match="/*" attribute-name="href">


### PR DESCRIPTION
It doesn't work properly with px:fileset-store.

Alternatively, we could fix px:fileset-store so that it
handles directories properly. That way, we would have a
way to represent empty directories in a d:fileset.

If we don't want to support handling empty directories
in d:filesets, please merge this PR.
