### PR TITLE
Added "encode-as-base64" option to px:unzip-fileset

### DIFF
--- a/zip-utils/src/main/resources/xml/xproc/unzip-fileset.xpl
+++ b/zip-utils/src/main/resources/xml/xproc/unzip-fileset.xpl
@@ -4,6 +4,7 @@
     
     <p:option name="href" required="true"/>
     <p:option name="unzipped-basedir" required="true"/>
+    <p:option name="encode-as-base64" select="'false'"/>
 
     <p:output port="fileset.out" primary="true">
         <p:pipe port="result" step="zip.fileset"/>
@@ -40,7 +41,7 @@
         <px:unzip>
             <p:with-option name="href" select="$href"/>
             <p:with-option name="file" select="/*/@href"/>
-            <p:with-option name="content-type" select="/*/@media-type"/>
+            <p:with-option name="content-type" select="if ($encode-as-base64='true') then 'application/octet-stream' else /*/@media-type"/>
         </px:unzip>
         <p:add-attribute match="/*" attribute-name="xml:base">
             <p:with-option name="attribute-value" select="resolve-uri($entry-href, $unzipped-basedir)"/>


### PR DESCRIPTION
Useful if you want to read the file contents byte-for-byte.
For instance, you can use it to validate the XML declarations of zipped XML files.
