### PR TITLE
correct status port mime

### DIFF
--- a/validation-utils/src/main/resources/xml/xproc/check-files-exist.xpl
+++ b/validation-utils/src/main/resources/xml/xproc/check-files-exist.xpl
@@ -42,7 +42,7 @@
         <p:pipe port="result" step="wrap-errors"/>
     </p:output>
     
-    <p:output port="validation-status" px:media-type="application/xml+vnd.pipeline.status">
+    <p:output port="validation-status" px:media-type="application/vnd.pipeline.status+xml">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
             <h1 px:role="name">validation-status</h1>
             <p px:role="desc">Validation status (http://code.google.com/p/daisy-pipeline/wiki/ValidationStatusXML) of the file check.</p>

--- a/validation-utils/src/main/resources/xml/xproc/check-files-wellformed.xpl
+++ b/validation-utils/src/main/resources/xml/xproc/check-files-wellformed.xpl
@@ -42,7 +42,7 @@
         <p:pipe port="result" step="process-errors"/>
     </p:output>
 
-    <p:output port="validation-status" px:media-type="application/xml+vnd.pipeline.status">
+    <p:output port="validation-status" px:media-type="application/vnd.pipeline.status+xml">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
             <h1 px:role="name">validation-status</h1>
             <p px:role="desc">Validation status (http://code.google.com/p/daisy-pipeline/wiki/ValidationStatusXML) of the file check.</p>

--- a/validation-utils/src/main/resources/xml/xproc/validation-status.xpl
+++ b/validation-utils/src/main/resources/xml/xproc/validation-status.xpl
@@ -22,7 +22,7 @@
         </p:documentation>
     </p:input>
     
-    <p:output port="result" px:media-type="application/xml+vnd.pipeline.status">
+    <p:output port="result" px:media-type="application/vnd.pipeline.status+xml">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
             <h1 px:role="name">result</h1>
             <p px:role="desc">Validation status (http://code.google.com/p/daisy-pipeline/wiki/ValidationStatusXML).</p>


### PR DESCRIPTION
fixes daisy/pipeline-issues#350

All references to the status port mime type is now corrected to "application/vnd.pipeline.status+xml".

<!---
@huboard:{"order":61.0,"custom_state":""}
-->
