### PR TITLE
Update XPath functions to Saxon 9.5 API

### DIFF
--- a/file-utils/src/main/java/org/daisy/saxon/functions/file/Expand83.java
+++ b/file-utils/src/main/java/org/daisy/saxon/functions/file/Expand83.java
@@ -2,9 +2,12 @@ package org.daisy.saxon.functions.file;
 
 import java.io.File;
 import java.net.URI;
+
 import net.sf.saxon.expr.XPathContext;
 import net.sf.saxon.lib.ExtensionFunctionCall;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.AtomicSequence;
+import net.sf.saxon.om.Sequence;
 import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.trans.XPathException;
@@ -38,14 +41,12 @@ public class Expand83 extends ExtensionFunctionDefinition {
 	public ExtensionFunctionCall makeCallExpression() {
 		return new ExtensionFunctionCall() {
 
-			@SuppressWarnings({ "unchecked", "rawtypes" })
-			public SequenceIterator call(SequenceIterator[] arguments,
-					XPathContext context) throws XPathException {
-
-				String uri = ((StringValue) arguments[0].next()).getStringValue();
+			@Override
+			public Sequence call(XPathContext context, Sequence[] arguments)
+					throws XPathException {
+				String uri = ((AtomicSequence) arguments[0]).getStringValue();
 				uri = Expand83.expand83(uri);
-				return SingletonIterator.makeIterator(new StringValue(
-						uri, BuiltInAtomicType.STRING));
+				return new StringValue(uri, BuiltInAtomicType.STRING);
 			}
 		};
 	}
@@ -53,13 +54,14 @@ public class Expand83 extends ExtensionFunctionDefinition {
 	/**
 	 * Expands 8.3 encoded path segments.
 	 *
-	 * For instance `C:\DOCUME~1\file.xml` will become `C:\Documents and Settings\file.xml`
+	 * For instance `C:\DOCUME~1\file.xml` will become `C:\Documents and
+	 * Settings\file.xml`
 	 */
 	public static String expand83(String uri) throws XPathException {
 		if (uri == null || !uri.startsWith("file:/")) {
 			return uri;
 		}
-		
+
 		try {
 			File file = new File(new URI(uri));
 			String expandedUri = expand83(file);
@@ -74,7 +76,10 @@ public class Expand83 extends ExtensionFunctionDefinition {
 		}
 	}
 
-	/** this is extracted out of `expand83(String)` because it can be unit tested with a custom File implementation. */
+	/**
+	 * this is extracted out of `expand83(String)` because it can be unit tested
+	 * with a custom File implementation.
+	 */
 	public static String expand83(File file) throws XPathException {
 		try {
 			if (file.exists()) {

--- a/file-utils/src/main/java/org/daisy/saxon/functions/file/FileExists.java
+++ b/file-utils/src/main/java/org/daisy/saxon/functions/file/FileExists.java
@@ -5,14 +5,13 @@ import java.io.File;
 import net.sf.saxon.expr.XPathContext;
 import net.sf.saxon.lib.ExtensionFunctionCall;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
-import net.sf.saxon.om.SequenceIterator;
+import net.sf.saxon.om.AtomicSequence;
+import net.sf.saxon.om.Sequence;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.trans.XPathException;
-import net.sf.saxon.tree.iter.SingletonIterator;
 import net.sf.saxon.type.BuiltInAtomicType;
 import net.sf.saxon.value.BooleanValue;
 import net.sf.saxon.value.SequenceType;
-import net.sf.saxon.value.StringValue;
 
 @SuppressWarnings("serial")
 public class FileExists extends ExtensionFunctionDefinition {
@@ -40,15 +39,15 @@ public class FileExists extends ExtensionFunctionDefinition {
 		return new ExtensionFunctionCall() {
 
 			@SuppressWarnings({ "unchecked", "rawtypes" })
-			public SequenceIterator call(SequenceIterator[] arguments,
-					XPathContext context) throws XPathException {
+			public Sequence call(XPathContext context, Sequence[] arguments)
+					throws XPathException {
 
 				try {
-					String path = ((StringValue) arguments[0].next())
+					String path = ((AtomicSequence) arguments[0])
 							.getStringValue();
-					boolean result = (path.isEmpty())?true:new File(path).exists();
-					return SingletonIterator.makeIterator(new BooleanValue(
-							result, BuiltInAtomicType.BOOLEAN));
+					boolean result = (path.isEmpty()) ? true : new File(path)
+							.exists();
+					return new BooleanValue(result, BuiltInAtomicType.BOOLEAN);
 				} catch (Exception e) {
 					throw new XPathException("pf:file-exists failed", e);
 				}

--- a/image-utils/src/main/java/org/daisy/saxon/functions/image/ImageDimensions.java
+++ b/image-utils/src/main/java/org/daisy/saxon/functions/image/ImageDimensions.java
@@ -9,6 +9,8 @@ import javax.imageio.ImageIO;
 import net.sf.saxon.expr.XPathContext;
 import net.sf.saxon.lib.ExtensionFunctionCall;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.LazySequence;
+import net.sf.saxon.om.Sequence;
 import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.trans.XPathException;
@@ -23,40 +25,47 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("serial")
 public class ImageDimensions extends ExtensionFunctionDefinition {
-	
+
 	private static final StructuredQName funcname = new StructuredQName("pf",
 			"http://www.daisy.org/ns/pipeline/functions", "image-dimensions");
-	
+
 	@Override
 	public SequenceType[] getArgumentTypes() {
 		return new SequenceType[] { SequenceType.SINGLE_STRING };
 	}
-	
+
 	public StructuredQName getFunctionQName() {
 		return funcname;
 	}
-	
+
 	public SequenceType getResultType(SequenceType[] arg0) {
 		return SequenceType.NUMERIC_SEQUENCE;
 	}
-	
+
 	@Override
 	public ExtensionFunctionCall makeCallExpression() {
 		return new ExtensionFunctionCall() {
-			@SuppressWarnings({ "unchecked", "rawtypes", "deprecation" })
-			public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+
+			@Override
+			public Sequence call(XPathContext context, Sequence[] arguments)
+					throws XPathException {
 				try {
-					String path = ((StringValue) arguments[0].next()).getStringValue();
-					BufferedImage image = ImageIO.read(new URL(URLDecoder.decode(path)));
-					return new ArrayIterator<IntegerValue>(new IntegerValue[]{
-							new BigIntegerValue(image.getWidth()),
-							new BigIntegerValue(image.getHeight())}); }
-				catch (Exception e) {
+					String path = ((StringValue) arguments[0])
+							.getStringValue();
+					BufferedImage image = ImageIO.read(new URL(URLDecoder
+							.decode(path)));
+					return new LazySequence(
+							new ArrayIterator < IntegerValue > (new IntegerValue[] {
+									new BigIntegerValue(image.getWidth()),
+									new BigIntegerValue(image.getHeight()) }));
+				} catch (Exception e) {
 					logger.error("pf:image-dimensions", e);
-					throw new XPathException("pf:image-dimensions failed", e); }
+					throw new XPathException("pf:image-dimensions failed", e);
+				}
 			}
 		};
 	}
-	
-	private static final Logger logger = LoggerFactory.getLogger(ImageDimensions.class);
+
+	private static final Logger logger = LoggerFactory
+			.getLogger(ImageDimensions.class);
 }


### PR DESCRIPTION
Saxon 9.5 introduced API breaks, notably in the XPath extension function APIs. This PR adapts our own extension functions to Saxon 9.5.
