### PR TITLE
Add a 2-args pf:normalize-uri that discards URI fragments

### DIFF
--- a/file-utils/src/main/resources/xml/xslt/uri-functions.xsl
+++ b/file-utils/src/main/resources/xml/xslt/uri-functions.xsl
@@ -71,6 +71,12 @@
 
     <xsl:function name="pf:normalize-uri" as="xs:string">
         <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="pf:normalize-uri($uri,true())"/>
+    </xsl:function>
+    
+    <xsl:function name="pf:normalize-uri" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:param name="fragment" as="xs:boolean?"/>
         <!--
             http://en.wikipedia.org/wiki/URL_normalization
             - path segment normalization
@@ -128,7 +134,7 @@
         <xsl:variable name="authority" select="$tokens[2]"/>
         <xsl:variable name="path" select="$tokens[3]"/>
         <xsl:variable name="query" select="$tokens[4]"/>
-        <xsl:variable name="fragment" select="$tokens[5]"/>
+        <xsl:variable name="fragment" select="if ($fragment) then $tokens[5] else ()"/>
 
         <!-- lower case scheme and authority components -->
         <xsl:variable name="scheme" select="lower-case($scheme)"/>

--- a/file-utils/src/test/xspec/uri-functions.xspec
+++ b/file-utils/src/test/xspec/uri-functions.xspec
@@ -356,6 +356,35 @@
             <x:expect label="grandchild directory with multipls dots and slashes" select="'/dir/sub/'"/>
         </x:scenario>
     </x:scenario>
+    
+    
+    <x:scenario label="function normalize-uri – two args">
+        <x:call function="pf:normalize-uri">
+            <x:param name="uri" select="''"/>
+            <x:param name="fragment" select="true()"/>
+        </x:call>
+        <x:scenario label="when the URI has a fragment and the second arg is true">
+            <x:call>
+                <x:param name="uri" select="'file.xml?q=a#id'"/>
+                <x:param name="fragment" select="true()"/>
+            </x:call>
+            <x:expect label="the fragment is kept" select="'file.xml?q=a#id'"/>
+        </x:scenario>
+        <x:scenario label="when the URI has a fragment and the second arg is false">
+            <x:call>
+                <x:param name="uri" select="'file.xml?q=a#id'"/>
+                <x:param name="fragment" select="false()"/>
+            </x:call>
+            <x:expect label="the fragment is discarded" select="'file.xml?q=a'"/>
+        </x:scenario>
+        <x:scenario label="when the URI is just a fragment ID and the second arg is false">
+            <x:call>
+                <x:param name="uri" select="'#id'"/>
+                <x:param name="fragment" select="false()"/>
+            </x:call>
+            <x:expect label="the fragment is discarded" select="''"/>
+        </x:scenario>
+    </x:scenario>
 
     <x:scenario label="function relativize-uri">
         <x:call function="pf:relativize-uri">


### PR DESCRIPTION
Useful notably when wanting to access the underneath resource, regardless of the fragment.
