### PR TITLE
Add safe check for XD0007 in px:mediatype-detect

### DIFF
--- a/mediatype-utils/src/main/resources/xml/xproc/mediatype.xpl
+++ b/mediatype-utils/src/main/resources/xml/xproc/mediatype.xpl
@@ -77,6 +77,7 @@
                             <p:pipe port="in-memory" step="main"/>
                         </p:input>
                     </p:split-sequence>
+                    <p:split-sequence test="position()=1" initial-only="true"/>
                 </p:group>
                 <p:count name="filecount-in-memory"/>
                 <p:identity>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <module>file-utils</module>
     <!-- <module>fileset-utils</module> -->
     <!-- <module>image-utils</module> -->
-    <!-- <module>mediatype-utils</module> -->
+    <module>mediatype-utils</module>
     <!-- <module>metadata-utils</module> -->
     <!-- <module>validation-utils</module> -->
     <!-- <module>zip-utils</module> -->
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>mediatype-utils</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>


### PR DESCRIPTION
When the same document appears more than once in the in-memory set,
`px:mediatype-detect` failed with XD0007 (sequence of doc not allowed
on a port).
This change adds a safe check for this case.
