### PR TITLE
Support !/ in target HREFs of file sets

### DIFF
--- a/mediatype-utils/src/main/resources/xml/xproc/mediatype.xpl
+++ b/mediatype-utils/src/main/resources/xml/xproc/mediatype.xpl
@@ -77,6 +77,7 @@
                             <p:pipe port="in-memory" step="main"/>
                         </p:input>
                     </p:split-sequence>
+                    <p:split-sequence test="position()=1" initial-only="true"/>
                 </p:group>
                 <p:count name="filecount-in-memory"/>
                 <p:identity>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <module>file-utils</module>
     <!-- <module>fileset-utils</module> -->
     <!-- <module>image-utils</module> -->
-    <!-- <module>mediatype-utils</module> -->
+    <module>mediatype-utils</module>
     <!-- <module>metadata-utils</module> -->
     <!-- <module>validation-utils</module> -->
     <!-- <module>zip-utils</module> -->
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>mediatype-utils</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>


### PR DESCRIPTION
"!/" is already supported in source HREFs, and denotes a path inside a ZIP file. px:fileset-store could use px:zip to zip up fileset entries that have "!/" in their target HREF.

The reason I hadn't considered this before is because I didn't realize px:zip takes a sequence of in-memory documents on its source port.

<!---
@huboard:{"order":70.0,"milestone_order":70,"custom_state":""}
-->
