### PR TITLE
Allow extensions in doctypes (e.g. for MathML in Daisy3)

### DIFF
--- a/file-utils/src/main/resources/xml/xproc/set-doctype.xpl
+++ b/file-utils/src/main/resources/xml/xproc/set-doctype.xpl
@@ -3,7 +3,7 @@
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
         <p>Sets, or deletes, the doctype of a file. If `doctype` is the empty string, the doctype will be deleted. It is an error if `doctype` does not match the regex
-            `^&lt;!DOCTYPE\s+\w+\s*(|SYSTEM\s+("[^"]*"|'[^']*')|PUBLIC\s+("[\s\w\-'()+,\./:=?;!*#@$_%]*"|'[\s\w\-()+,\./:=?;!*#@$_%]*')\s+("[^"]*"|'[^']*'))>$`. The result port will contain a
+            `^&lt;!DOCTYPE\s+\w+\s*(|SYSTEM\s+("[^"]*"|'[^']*')|PUBLIC\s+("[\s\w\-'()+,\./:=?;!*#@$_%]*"|'[\s\w\-()+,\./:=?;!*#@$_%]*')\s+("[^"]*"|'[^']*'))(\s*\[[^\]]+\])?>$`. The result port will contain a
             `c:result` document with the URI to the file as its text node.</p>
     </p:documentation>
 
@@ -13,10 +13,10 @@
     <p:option name="href" required="true"/>
     <p:option name="doctype" required="true"/>
     <p:option name="encoding" select="'utf-8'"/>
-    
+
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
-    
-    <p:variable name="doctype-regex" select="'^&lt;!DOCTYPE\s+\w+\s*(|SYSTEM\s+(&quot;[^&quot;]*&quot;|''[^'']*'')|PUBLIC\s+(&quot;[\s\w\-''()+,\./:=?;!*#@$_%]*&quot;|''[\s\w\-()+,\./:=?;!*#@$_%]*'')\s+(&quot;[^&quot;]*&quot;|''[^'']*''))>$'"/>
+
+    <p:variable name="doctype-regex" select="'^&lt;!DOCTYPE\s+\w+\s*(|SYSTEM\s+(&quot;[^&quot;]*&quot;|''[^'']*'')|PUBLIC\s+(&quot;[\s\w\-''()+,\./:=?;!*#@$_%]*&quot;|''[\s\w\-()+,\./:=?;!*#@$_%]*'')\s+(&quot;[^&quot;]*&quot;|''[^'']*''))(\s*\[[^\]]+\])?>$'"/>
 
     <p:add-attribute match="/*" attribute-name="href">
         <p:with-option name="attribute-value" select="$href"/>
@@ -26,28 +26,28 @@
             </p:inline>
         </p:input>
     </p:add-attribute>
+
     <p:add-attribute match="/*" attribute-name="override-content-type">
         <p:with-option name="attribute-value" select="concat('text/plain; charset=',$encoding)"/>
     </p:add-attribute>
-    
+
     <px:assert message="The href must be an absolute file URI: $1" error-code="DPSD01">
         <p:with-option name="param1" select="$href"/>
         <p:with-option name="test" select="matches($href,'^file:/.*[^/]$')"/>
     </px:assert>
-    
+
     <px:assert message="The doctype must either be empty, or be a valid DOCTYPE declaration: $1" error-code="DPSD02">
         <p:with-option name="param1" select="$doctype"/>
         <p:with-option name="test" select="$doctype='' or matches($doctype,$doctype-regex)"/>
     </px:assert>
-    
+
     <p:http-request/>
     <p:string-replace match="/*/text()">
-        <p:with-option name="replace" select="concat('replace(.,''^(&lt;\?[^&gt;]*&gt;\s*)*\s*?(&lt;!DOCTYPE\s[^&gt;]*&gt;\n?)?(.)'',''',concat('$1',$doctype,'&#10;$3'),''')')"/>
+      <p:with-option name="replace" select="concat('replace(.,''^(&lt;\?[^&gt;]*&gt;\s*)*\s*?(&lt;!DOCTYPE\s[^&gt;]*&gt;\n?)?(.)'',''',concat('$1', replace($doctype, '''', ''''''),'&#10;$3'),''')')"/>
     </p:string-replace>
     <p:store method="text" name="store">
         <p:with-option name="href" select="$href"/>
         <p:with-option name="encoding" select="$encoding"/>
     </p:store>
-
 
 </p:declare-step>

--- a/file-utils/src/test/xprocspec/samples/set-doctype.add-extension.xml
+++ b/file-utils/src/test/xprocspec/samples/set-doctype.add-extension.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>XHTML5</title>
+    </head>
+    <body>
+        <h1>XHTML5</h1>
+    </body>
+</html>

--- a/file-utils/src/test/xprocspec/set-doctype.xprocspec
+++ b/file-utils/src/test/xprocspec/set-doctype.xprocspec
@@ -72,40 +72,72 @@
             <x:option name="doctype" select="'&lt;!DOCTYPE html&gt;'"/>
             <x:option name="href" select="resolve-uri('samples/set-doctype.with-doctype.xml',base-uri(.))"/>
         </x:call>
-        
+
         <x:context label="the stored document">
             <x:document type="file" base-uri="temp-dir" href="set-doctype.with-doctype.xml" method="text"/>
         </x:context>
         <x:expect label="the document should start with a xml declaration" type="xpath" test="starts-with(/*/text(),'&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;')"/>
         <x:expect label="the document should contain the correct DOCTYPE declaration" type="xpath" test="matches(/*/text(),'.*&lt;!DOCTYPE html&gt;.*&lt;html.*','s')"/>
     </x:scenario>
-    
+
     <x:scenario label="Scenario for testing px:set-doctype - without a xml declaration">
         <x:call step="test:test">
             <x:option name="target" select="resolve-uri('set-doctype.without-xml-declaration.xml',$temp-dir)"/>
             <x:option name="doctype" select="'&lt;!DOCTYPE html&gt;'"/>
             <x:option name="href" select="resolve-uri('samples/set-doctype.without-xml-declaration.xml',base-uri(.))"/>
         </x:call>
-        
+
         <x:context label="the stored document">
             <x:document type="file" base-uri="temp-dir" href="set-doctype.without-xml-declaration.xml" method="text"/>
         </x:context>
         <x:expect label="the document should not start with a xml declaration" type="xpath" test="not(starts-with(/*/text(),'&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;'))"/>
         <x:expect label="the document should contain the correct DOCTYPE declaration" type="xpath" test="matches(/*/text(),'.*&lt;!DOCTYPE html&gt;.*&lt;html.*','s')"/>
     </x:scenario>
-    
+
     <x:scenario label="Scenario for testing px:set-doctype - deleting an existing doctype declaration">
         <x:call step="test:test">
             <x:option name="target" select="resolve-uri('set-doctype.delete-existing.xml',$temp-dir)"/>
             <x:option name="doctype" select="''"/>
             <x:option name="href" select="resolve-uri('samples/set-doctype.without-xml-declaration.xml',base-uri(.))"/>
         </x:call>
-        
+
         <x:context label="the stored document">
             <x:document type="file" base-uri="temp-dir" href="set-doctype.delete-existing.xml" method="text"/>
         </x:context>
         <x:expect label="the document should not start with a xml declaration" type="xpath" test="not(starts-with(/*/text(),'&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;'))"/>
         <x:expect label="the document should not contain a DOCTYPE declaration" type="xpath" test="not(matches(/*/text(),'.*&lt;!DOCTYPE[^&gt;]*&gt;.*&lt;html.*','s'))"/>
+    </x:scenario>
+
+    <x:scenario label="Scenario for testing px:set-doctype - with a MathML doctype extension">
+        <x:call step="test:test">
+            <x:option name="target" select="resolve-uri('set-doctype.add-extension.xml',$temp-dir)"/>
+            <x:option name="doctype"
+		      select="'&lt;!DOCTYPE dtbook PUBLIC &quot;-//NISO//DTD dtbook 2005-2//EN&quot;
+	      &quot;http://www.daisy.org/z3986/2005/dtbook-2005-2.dtd&quot;[
+	      &lt;!ENTITY % MATHML.prefixed &quot;INCLUDE&quot; &gt;
+	      &lt;!ENTITY % MATHML.prefix &quot;m&quot;&gt;
+	      &lt;!ENTITY % MATHML.Common.attrib
+	      &quot;xlink:href    CDATA       #IMPLIED
+	      xlink:type     CDATA       #IMPLIED
+	      class          CDATA       #IMPLIED
+	      style          CDATA       #IMPLIED
+	      id             ID          #IMPLIED
+	      xref           IDREF       #IMPLIED
+	      other          CDATA       #IMPLIED
+	      xmlns:dtbook   CDATA       #FIXED ''http://www.daisy.org/z3986/2005/dtbook/''
+	      dtbook:smilref CDATA       #IMPLIED&quot;&gt;
+	      &lt;!ENTITY % mathML2 PUBLIC &quot;-//W3C//DTD MathML 2.0//EN&quot;
+	      &quot;http://www.w3.org/Math/DTD/mathml2/mathml2.dtd&quot;&gt;
+	      %mathML2;
+	      &lt;!ENTITY % externalFlow &quot;| m:math&quot;&gt;
+	      &lt;!ENTITY % externalNamespaces &quot;xmlns:m CDATA #FIXED
+	      ''http://www.w3.org/1998/Math/MathML''&quot;&gt;]&gt;'"/>
+            <x:option name="href" select="resolve-uri('samples/set-doctype.add-extension.xml',base-uri(.))"/>
+        </x:call>
+        <x:context label="the stored document">
+            <x:document type="file" base-uri="temp-dir" href="set-doctype.add-extension.xml" method="text"/>
+        </x:context>
+        <x:expect label="the document DOCTYPE should contain a MathML extension" type="xpath" test="matches(/*/text(),'.*&lt;!DOCTYPE.*MATHML\.Common.*&gt;.*&lt;html.*','s')"/>
     </x:scenario>
 
 </x:description>


### PR DESCRIPTION
It may conflict with some of @josteinaj's future modifications. So let me know if I should wait and rebase before submitting this modification. 