### PR TITLE
Audio was missing from output of dtbook-to-epub3 and dtbook-to-daisy3 with TTS

### DIFF
--- a/fileset-utils/src/main/resources/xml/xproc/fileset-add-entry.xpl
+++ b/fileset-utils/src/main/resources/xml/xproc/fileset-add-entry.xpl
@@ -50,7 +50,7 @@
     <p:with-option name="attribute-value" select="if (starts-with($href, $fileset-base) and ends-with($fileset-base,'/')) then substring-after($href, $fileset-base) else $href"/>
   </p:add-attribute>
   <p:add-attribute match="/*" attribute-name="original-href">
-    <p:with-option name="attribute-value" select="if ($original-href and $fileset-base) then resolve-uri($original-href, $fileset-base) else ''"/>
+    <p:with-option name="attribute-value" select="if ($original-href) then resolve-uri($original-href, $fileset-base) else ''"/>
   </p:add-attribute>
   <p:delete match="@media-type[not(normalize-space())]"/>
   <p:delete match="@original-href[not(normalize-space())]"/>

--- a/fileset-utils/src/test/xprocspec/fileset-add-entry.xprocspec
+++ b/fileset-utils/src/test/xprocspec/fileset-add-entry.xprocspec
@@ -135,4 +135,50 @@
         </x:expect>
     </x:scenario>
 
+    <x:scenario label="add-entry-original-href">
+        <x:call step="px:fileset-add-entry">
+            <x:option name="href" select="'doc.html'"/>
+            <x:option name="original-href" select="'file:/var/folders/mr/f6s9zqtn03d8rgzxb96_2bh00000gn/T/-1kf6683sr37ic7r60abkgeaant/doc.html'"/>
+            <x:input port="source">
+                <x:document type="inline">
+                    <d:fileset xml:base="file:/users/me/dir/"/>
+                </x:document>
+            </x:input>
+        </x:call>
+        <x:context label="the result port">
+            <x:document type="port" port="result"/>
+        </x:context>
+        <x:expect type="compare" label="the result should have a original-href attribute">
+            <x:document type="inline">
+                <d:fileset xml:base="file:/users/me/dir/">
+                    <d:file href="doc.html"
+                            original-href="file:/var/folders/mr/f6s9zqtn03d8rgzxb96_2bh00000gn/T/-1kf6683sr37ic7r60abkgeaant/doc.html"/>
+                </d:fileset>
+            </x:document>
+        </x:expect>
+    </x:scenario>
+    
+    <x:scenario label="add-entry-original-href-no-fileset-base">
+        <x:call step="px:fileset-add-entry">
+            <x:option name="href" select="'file:/users/me/dir/doc.html'"/>
+            <x:option name="original-href" select="'file:/var/folders/mr/f6s9zqtn03d8rgzxb96_2bh00000gn/T/-1kf6683sr37ic7r60abkgeaant/doc.html'"/>
+            <x:input port="source">
+                <x:document type="inline">
+                    <d:fileset/>
+                </x:document>
+            </x:input>
+        </x:call>
+        <x:context label="the result port">
+            <x:document type="port" port="result"/>
+        </x:context>
+        <x:expect type="compare" label="the result file should have a original-href attribute">
+            <x:document type="inline">
+                <d:fileset>
+                    <d:file href="file:/users/me/dir/doc.html"
+                            original-href="file:/var/folders/mr/f6s9zqtn03d8rgzxb96_2bh00000gn/T/-1kf6683sr37ic7r60abkgeaant/doc.html"/>
+                </d:fileset>
+            </x:document>
+        </x:expect>
+    </x:scenario>
+    
 </x:description>


### PR DESCRIPTION
This was reported by Greg Kearney

This was due to a bug in fileset-utils which got introduced in commit bfe936c.